### PR TITLE
Removing Picard MarkDuplicates step

### DIFF
--- a/tools/multiqc.wdl
+++ b/tools/multiqc.wdl
@@ -5,7 +5,6 @@
 
 task multiqc {
     File star
-    File dups
     String validate_sam_string
     Array[File] qualimap_bamqc
     Array[File] qualimap_rnaseq
@@ -14,7 +13,6 @@ task multiqc {
 
     command {
         echo ${star} > file_list.txt
-        echo ${dups} >> file_list.txt
         echo ${validate_sam_string} > validate_sam.txt
         echo validate_sam.txt >> file_list.txt
         for file in ${sep=' ' qualimap_bamqc} ; do

--- a/workflows/star-qc.wdl
+++ b/workflows/star-qc.wdl
@@ -28,7 +28,6 @@ workflow star_qc {
     Int ncpu
 
     call samtools.quickcheck { input: bam=bam }
-    call picard.mark_duplicates { input: bam=bam }
     call picard.validate_bam { input: bam=bam }
     call fastqc.fastqc { input: bam=bam, ncpu=ncpu }
     call qualimap.bamqc { input: bam=bam, ncpu=ncpu }

--- a/workflows/start-to-finish.wdl
+++ b/workflows/start-to-finish.wdl
@@ -1,7 +1,7 @@
 ## Description: 
 ##
 ## This WDL workflow runs the STAR RNA-seq alignment workflow for St. Jude Cloud. The workflow takes an input BAM file and splits it into fastq files for each read in the pair. 
-## The read pairs are then passed through STAR alignment to generate a BAM file. The BAM is run through Picard's MarkDuplicates and several QC steps including FastQC and Qualimap.
+## The read pairs are then passed through STAR alignment to generate a BAM file. The BAM is run through several QC steps including FastQC and Qualimap.
 ## Quantification is done using htseq-count. A final QC report is produced by MultiQC to generate a combined overview of the QC results for the sample.  
 ##
 ## Inputs: 

--- a/workflows/start-to-finish.wdl
+++ b/workflows/start-to-finish.wdl
@@ -63,23 +63,21 @@ workflow start_to_finish {
             output_prefix="out",
             read_groups=prepare_read_groups_for_star.out
     }
-    call picard.mark_duplicates { input: bam=star_alignment.star_bam }
-    call picard.validate_bam { input: bam=mark_duplicates.out }
+    call picard.validate_bam { input: bam=star_alignment.star_bam }
     call qc.parse_validate_bam { input: in=validate_bam.out }
-    call fastqc.fastqc { input: bam=mark_duplicates.out, ncpu=ncpu }   
-    call rseqc.infer_experiment { input: bam=mark_duplicates.out, refgene_bed=refgene_bed}
+    call fastqc.fastqc { input: bam=star_alignment.star_bam, ncpu=ncpu }   
+    call rseqc.infer_experiment { input: bam=star_alignment.star_bam, refgene_bed=refgene_bed}
     call qc.parse_infer_experiment { input: in=infer_experiment.out } 
-    call qualimap.bamqc { input: bam=mark_duplicates.out, ncpu=ncpu }
-    call qualimap.rnaseq { input: bam=mark_duplicates.out, gencode_gtf=gencode_gtf }
-    call htseq.count { input: bam=mark_duplicates.out, gtf=gencode_gtf }
-    call samtools.flagstat { input: bam=mark_duplicates.out }
-    call samtools.index { input: bam=mark_duplicates.out }
-    call md5sum.compute_checksum { input: infile=mark_duplicates.out }
-    call deeptools.bamCoverage { input: bam=mark_duplicates.out, bai=index.bai }
+    call qualimap.bamqc { input: bam=star_alignment.star_bam, ncpu=ncpu }
+    call qualimap.rnaseq { input: bam=star_alignment.star_bam, gencode_gtf=gencode_gtf }
+    call htseq.count { input: bam=star_alignment.star_bam, gtf=gencode_gtf }
+    call samtools.flagstat { input: bam=star_alignment.star_bam }
+    call samtools.index { input: bam=star_alignment.star_bam }
+    call md5sum.compute_checksum { input: infile=star_alignment.star_bam } 
+    call deeptools.bamCoverage { input: bam=star_alignment.star_bam, bai=index.bai }
     call multiqc.multiqc {
         input:
             star=star_alignment.star_bam,
-            dups=mark_duplicates.out,
             validate_sam_string=validate_bam.out,
             qualimap_bamqc=bamqc.out_files,
             qualimap_rnaseq=rnaseq.out_files,


### PR DESCRIPTION
Addresses feedback on the RFC from Kyle regarding duplicate marking. Removing that step and updating the downstream steps to use the STAR aligned BAM directly. 