### PR TITLE
Changing STAR alignment to use either the number of cores if specified or all available cores

### DIFF
--- a/tools/deeptools.wdl
+++ b/tools/deeptools.wdl
@@ -13,7 +13,7 @@ task bamCoverage {
         Int max_retries = 1
         Int memory_gb = 5
         Int ncpu = 1
-        Boolean use_ncpu = false
+        Boolean detect_nproc = false
     }
 
     Float bam_size = size(bam, "GiB")
@@ -23,7 +23,7 @@ task bamCoverage {
         set -euo pipefail
         
         n_cores=~{ncpu}
-        if [ ${true='true' false='' use_ncpu} ]
+        if [ ${true='true' false='' detect_nproc} ]
         then
             n_cores="max""
         fi

--- a/tools/deeptools.wdl
+++ b/tools/deeptools.wdl
@@ -25,7 +25,7 @@ task bamCoverage {
         n_cores=~{ncpu}
         if [ ${true='true' false='' detect_nproc} ]
         then
-            n_cores="max""
+            n_cores="max"
         fi
 
         if [ ! -e ~{bam}.bai ]

--- a/tools/deeptools.wdl
+++ b/tools/deeptools.wdl
@@ -12,6 +12,8 @@ task bamCoverage {
         String prefix = basename(bam, ".bam")
         Int max_retries = 1
         Int memory_gb = 5
+        Int ncpu = 1
+        Boolean use_ncpu = false
     }
 
     Float bam_size = size(bam, "GiB")
@@ -20,15 +22,22 @@ task bamCoverage {
     command {
         set -euo pipefail
         
+        n_cores=~{ncpu}
+        if [ ${true='true' false='' use_ncpu} ]
+        then
+            n_cores="max""
+        fi
+
         if [ ! -e ~{bam}.bai ]
         then 
             ln -s ~{bai} ~{bam}.bai
         fi
  
-        bamCoverage --bam ~{bam} --outFileName ~{prefix}.bw --outFileFormat bigwig --numberOfProcessors "max"
+        bamCoverage --bam ~{bam} --outFileName ~{prefix}.bw --outFileFormat bigwig --numberOfProcessors "$n_cores"
     }
 
     runtime {
+        cpu: ncpu
         disk: disk_size + " GB"
         memory: memory_gb + " GB"
         docker: 'stjudecloud/deeptools:1.0.0'

--- a/tools/samtools.wdl
+++ b/tools/samtools.wdl
@@ -43,7 +43,7 @@ task split {
         String prefix = basename(bam, ".bam")
         Int max_retries = 1
         Int? disk_size_gb
-        Boolean use_ncpu = false
+        Boolean detect_nproc = false
     }
 
     Float bam_size = size(bam, "GiB")
@@ -53,7 +53,7 @@ task split {
         set -euo pipefail
         
         n_cores=~{ncpu}
-        if [ ${true='true' false='' use_ncpu} ]
+        if [ ${true='true' false='' detect_nproc} ]
         then
             n_cores=`nproc`
         fi
@@ -134,7 +134,7 @@ task index {
         String outfile = basename(bam)+".bai"
         Int max_retries = 1
         Int memory_gb = 15
-        Boolean use_ncpu = false
+        Boolean detect_nproc = false
     }
 
     Float bam_size = size(bam, "GiB")
@@ -142,7 +142,7 @@ task index {
 
     command {
         n_cores=~{ncpu}
-        if [ ${true='true' false='' use_ncpu} ]
+        if [ ${true='true' false='' detect_nproc} ]
         then
             n_cores=`nproc`
         fi
@@ -181,7 +181,7 @@ task subsample {
         Int max_retries = 1
         Int desired_reads = 500000
         Int ncpu = 1
-        Boolean use_ncpu = false
+        Boolean detect_nproc = false
     }
 
     Float bam_size = size(bam, "GiB")
@@ -191,7 +191,7 @@ task subsample {
         set -euo pipefail
 
         n_cores=~{ncpu}
-        if [ ${true='true' false='' use_ncpu} ]
+        if [ ${true='true' false='' detect_nproc} ]
         then
             n_cores=`nproc`
         fi

--- a/tools/samtools.wdl
+++ b/tools/samtools.wdl
@@ -43,6 +43,7 @@ task split {
         String prefix = basename(bam, ".bam")
         Int max_retries = 1
         Int? disk_size_gb
+        Boolean use_ncpu = false
     }
 
     Float bam_size = size(bam, "GiB")
@@ -51,8 +52,14 @@ task split {
     command {
         set -euo pipefail
         
-        samtools split --threads ~{ncpu} -u ~{prefix}.unaccounted_reads.bam -f '%*_%!.%.' ~{bam}
-        samtools view ~{prefix}.unaccounted_reads.bam > unaccounted_reads.bam
+        n_cores=~{ncpu}
+        if [ ${true='true' false='' use_ncpu} ]
+        then
+            n_cores=`nproc`
+        fi
+
+        samtools split --threads $n_cores -u ~{prefix}.unaccounted_reads.bam -f '%*_%!.%.' ~{bam}
+        samtools view  --threads $n_cores ~{prefix}.unaccounted_reads.bam > unaccounted_reads.bam
         if ~{default='true' reject_unaccounted} && [ -s unaccounted_reads.bam ]
             then exit 1; 
             else rm ~{prefix}.unaccounted_reads.bam
@@ -123,19 +130,28 @@ task flagstat {
 task index {
     input {
         File bam
+        Int ncpu = 1
         String outfile = basename(bam)+".bai"
         Int max_retries = 1
         Int memory_gb = 15
+        Boolean use_ncpu = false
     }
 
     Float bam_size = size(bam, "GiB")
     Int disk_size = ceil((bam_size * 2) + 10)
 
     command {
-        samtools index ~{bam} ~{outfile}
+        n_cores=~{ncpu}
+        if [ ${true='true' false='' use_ncpu} ]
+        then
+            n_cores=`nproc`
+        fi
+
+        samtools index --threads $n_cores ~{bam} ~{outfile}
     }
 
     runtime {
+        cpu: ncpu
         disk: disk_size + " GB"
         docker: 'stjudecloud/samtools:1.0.0'
         memory: memory_gb + " GB"
@@ -164,6 +180,8 @@ task subsample {
         String outname = basename(bam, ".bam") + ".subsampled.bam"
         Int max_retries = 1
         Int desired_reads = 500000
+        Int ncpu = 1
+        Boolean use_ncpu = false
     }
 
     Float bam_size = size(bam, "GiB")
@@ -171,19 +189,25 @@ task subsample {
 
     command <<<
         set -euo pipefail
-        
-        if [[ "$(samtools view ~{bam} | head -n ~{desired_reads} | wc -l)" -ge "~{desired_reads}" ]]; then
+
+        n_cores=~{ncpu}
+        if [ ${true='true' false='' use_ncpu} ]
+        then
+            n_cores=`nproc`
+        fi
+
+        if [[ "$(samtools view --threads $n_cores ~{bam} | head -n ~{desired_reads} | wc -l)" -ge "~{desired_reads}" ]]; then
             # the BAM has at least ~{desired_reads} reads, meaning we should
             # subsample it.
             initial_frac=0.00001
-            initial_reads=$(samtools view -s $initial_frac ~{bam} | wc -l)
+            initial_reads=$(samtools view --threads $n_cores -s $initial_frac ~{bam} | wc -l)
             frac=$( \
                 awk -v desired_reads=~{desired_reads} \
                     -v initial_reads="$initial_reads" \
                     -v initial_frac=$initial_frac \
                         'BEGIN{printf "%1.8f", ( desired_reads / initial_reads * initial_frac )}' \
                 )
-            samtools view -h -b -s "$frac" ~{bam} > ~{outname}
+            samtools view --threads $n_cores -h -b -s "$frac" ~{bam} > ~{outname}
         else
             # the BAM has less than ~{desired_reads} reads, meaning we should
             # just use it directly without subsampling.
@@ -196,6 +220,7 @@ task subsample {
     }
 
     runtime {
+        cpu: ncpu
         disk: disk_size + " GB"
         docker: 'stjudecloud/samtools:1.0.0'
         maxRetries: max_retries

--- a/tools/star.wdl
+++ b/tools/star.wdl
@@ -15,7 +15,7 @@ task build_db {
         Int memory_gb = 50
         Int? disk_size_gb
         Int max_retries = 1
-        Boolean use_ncpu = false
+        Boolean detect_nproc = false
     }
 
     String stardb_out_name = stardb_dir_name + ".tar.gz"
@@ -27,7 +27,7 @@ task build_db {
         set -euo pipefail
 
         n_cores=~{ncpu}
-        if [ ${true='true' false='' use_ncpu} ]
+        if [ ${true='true' false='' detect_nproc} ]
         then
             n_cores=`nproc`
         fi
@@ -85,7 +85,7 @@ task alignment {
         Int memory_gb = 50
         Int? disk_size_gb
         Int max_retries = 1
-        Boolean use_ncpu = false
+        Boolean detect_nproc = false
     }
     
     String stardb_dir = basename(stardb_tar_gz, ".tar.gz")
@@ -98,7 +98,7 @@ task alignment {
         set -euo pipefail
 
         n_cores=~{ncpu}
-        if [ ${true='true' false='' use_ncpu} ]
+        if [ ${true='true' false='' detect_nproc} ]
         then
             n_cores=`nproc`
         fi

--- a/workflows/general/bam-to-fastqs.wdl
+++ b/workflows/general/bam-to-fastqs.wdl
@@ -45,6 +45,7 @@ workflow bam_to_fastqs {
         Int samtools_sort_ncpu = 1
         Int bam_to_fastq_memory_gb = 40
         Int max_retries = 1
+        Boolean use_ncpu = false
     }
 
     parameter_meta {
@@ -55,7 +56,7 @@ workflow bam_to_fastqs {
     }
 
     call samtools.quickcheck { input: bam=bam, max_retries=max_retries }
-    call samtools.split { input: ncpu=samtools_sort_ncpu, bam=bam, max_retries=max_retries }
+    call samtools.split { input: ncpu=samtools_sort_ncpu, bam=bam, max_retries=max_retries, use_ncpu=use_ncpu }
     scatter (split_bam in split.split_bams) {
         call picard.bam_to_fastq { input: bam=split_bam, memory_gb=bam_to_fastq_memory_gb, max_retries=max_retries }
     }

--- a/workflows/general/bam-to-fastqs.wdl
+++ b/workflows/general/bam-to-fastqs.wdl
@@ -45,7 +45,7 @@ workflow bam_to_fastqs {
         Int samtools_sort_ncpu = 1
         Int bam_to_fastq_memory_gb = 40
         Int max_retries = 1
-        Boolean use_ncpu = false
+        Boolean detect_nproc = false
     }
 
     parameter_meta {
@@ -56,7 +56,7 @@ workflow bam_to_fastqs {
     }
 
     call samtools.quickcheck { input: bam=bam, max_retries=max_retries }
-    call samtools.split { input: ncpu=samtools_sort_ncpu, bam=bam, max_retries=max_retries, use_ncpu=use_ncpu }
+    call samtools.split { input: ncpu=samtools_sort_ncpu, bam=bam, max_retries=max_retries, detect_nproc=detect_nproc }
     scatter (split_bam in split.split_bams) {
         call picard.bam_to_fastq { input: bam=split_bam, memory_gb=bam_to_fastq_memory_gb, max_retries=max_retries }
     }

--- a/workflows/rnaseq/rnaseq-standard.wdl
+++ b/workflows/rnaseq/rnaseq-standard.wdl
@@ -57,7 +57,7 @@ workflow rnaseq_standard {
         strand: "empty, 'Stranded-Reverse', 'Stranded-Forward', or 'Unstranded'. If missing, will be inferred"
         output_prefix: "Prefix for output files"
         max_retries: "Number of times to retry failed steps"
-        detect_nproc: "Determine number of cores and use all for multi-core steps"
+        detect_nproc: "Use all available cores for multi-core steps"
     }
 
     String provided_strand = strand

--- a/workflows/rnaseq/rnaseq-standard.wdl
+++ b/workflows/rnaseq/rnaseq-standard.wdl
@@ -47,7 +47,7 @@ workflow rnaseq_standard {
         String strand = ""
         String output_prefix = basename(input_bam, ".bam")
         Int max_retries = 1
-        Boolean use_ncpu = false
+        Boolean detect_nproc = false
     }
 
     parameter_meta {
@@ -57,7 +57,7 @@ workflow rnaseq_standard {
         strand: "empty, 'Stranded-Reverse', 'Stranded-Forward', or 'Unstranded'. If missing, will be inferred"
         output_prefix: "Prefix for output files"
         max_retries: "Number of times to retry failed steps"
-        use_ncpu: "Determine number of cores and use all for multi-core steps"
+        detect_nproc: "Determine number of cores and use all for multi-core steps"
     }
 
     String provided_strand = strand
@@ -66,7 +66,7 @@ workflow rnaseq_standard {
     call picard.validate_bam as validate_input_bam { input: bam=input_bam, max_retries=max_retries }
 
     call util.get_read_groups { input: bam=validate_input_bam.validated_bam, max_retries=max_retries }
-    call b2fq.bam_to_fastqs { input: bam=validate_input_bam.validated_bam, max_retries=max_retries, use_ncpu=use_ncpu }
+    call b2fq.bam_to_fastqs { input: bam=validate_input_bam.validated_bam, max_retries=max_retries, detect_nproc=detect_nproc }
     call star.alignment {
         input:
             read_one_fastqs=bam_to_fastqs.read1s,
@@ -75,10 +75,10 @@ workflow rnaseq_standard {
             output_prefix=output_prefix,
             read_groups=get_read_groups.out,
             max_retries=max_retries,
-            use_ncpu=use_ncpu
+            detect_nproc=detect_nproc
     }
     call picard.sort as picard_sort { input: bam=alignment.star_bam, max_retries=max_retries }
-    call samtools.index as samtools_index { input: bam=picard_sort.sorted_bam, max_retries=max_retries, use_ncpu=use_ncpu }
+    call samtools.index as samtools_index { input: bam=picard_sort.sorted_bam, max_retries=max_retries, detect_nproc=detect_nproc }
     call picard.validate_bam { input: bam=picard_sort.sorted_bam, max_retries=max_retries }
     call ngsderive.infer_strand as ngsderive_strandedness { input: bam=picard_sort.sorted_bam, bai=samtools_index.bai, gtf=gencode_gtf, max_retries=max_retries }
     call htseq.count as htseq_count { input: bam=picard_sort.sorted_bam, gtf=gencode_gtf, provided_strand=provided_strand, inferred_strand=ngsderive_strandedness.strandedness, max_retries=max_retries }

--- a/workflows/rnaseq_expression_classification/rnaseq_expression_classification.wdl
+++ b/workflows/rnaseq_expression_classification/rnaseq_expression_classification.wdl
@@ -57,12 +57,12 @@ workflow rnaseq_expression_classification {
         File? blood_covariates
         File? brain_covariates
         File? solid_covariates
-        Boolean use_ncpu = false
+        Boolean detect_nproc = false
     }
 
     scatter (bam in in_bams) {
         String name = basename(bam, ".bam")
-        call rnav2.rnaseq_standard { input: gencode_gtf=gencode_gtf, input_bam=bam, stardb_tar_gz=stardb_tar_gz, output_prefix=name, strand="", use_ncpu=use_ncpu }
+        call rnav2.rnaseq_standard { input: gencode_gtf=gencode_gtf, input_bam=bam, stardb_tar_gz=stardb_tar_gz, output_prefix=name, strand="", detect_nproc=detect_nproc }
     }
 
     if (! defined(reference_counts)){
@@ -117,5 +117,6 @@ workflow rnaseq_expression_classification {
             choices: ['blood', 'brain', 'solid']
         }
         output_filename: "Name for the output HTML RNA-Seq Expression Classification plot"
+        detect_nproc: "Determine number of cores and use all for multi-core steps"
     }
 }

--- a/workflows/rnaseq_expression_classification/rnaseq_expression_classification.wdl
+++ b/workflows/rnaseq_expression_classification/rnaseq_expression_classification.wdl
@@ -57,11 +57,12 @@ workflow rnaseq_expression_classification {
         File? blood_covariates
         File? brain_covariates
         File? solid_covariates
+        Boolean use_ncpu = false
     }
 
     scatter (bam in in_bams) {
         String name = basename(bam, ".bam")
-        call rnav2.rnaseq_standard { input: gencode_gtf=gencode_gtf, input_bam=bam, stardb_tar_gz=stardb_tar_gz, output_prefix=name, strand="" }
+        call rnav2.rnaseq_standard { input: gencode_gtf=gencode_gtf, input_bam=bam, stardb_tar_gz=stardb_tar_gz, output_prefix=name, strand="", use_ncpu=use_ncpu }
     }
 
     if (! defined(reference_counts)){


### PR DESCRIPTION
In cloud environments, STAR defaulted to 1 core despite the instance having multiple cores to satisfy the memory requirement. This changes the threading of STAR to use all available cores, unless the number of CPUs was explicitly passed.