### PR TITLE
fix: changed samtools index threads option

### DIFF
--- a/tools/samtools.wdl
+++ b/tools/samtools.wdl
@@ -147,7 +147,7 @@ task index {
             n_cores=`nproc`
         fi
 
-        samtools index --threads $n_cores ~{bam} ~{outfile}
+        samtools index -@ $n_cores ~{bam} ~{outfile}
     }
 
     runtime {


### PR DESCRIPTION
While running my CI RNA-Seq job on staging, I got an error while running the workflow. I thought it was something I did because I was changing how the pod was running the workflow, but on looking further it was `samtools index` erroring due to an invalid option.

This was the logs:
```
index: invalid option -- '-'
Usage: samtools index [-bc] [-m INT] <in.bam> [out.index]
Options:
  -b       Generate BAI-format index for BAM files [default]
  -c       Generate CSI-format index for BAM files
  -m INT   Set minimum interval size for CSI indices to 2^INT [14]
  -@ INT   Sets the number of threads [none]
```

I've updated the workflow with the expected flag, but I thought this was a good case of the CI picking up an error (albeit after it was merged). 