### PR TITLE
HTSeq output rename

### DIFF
--- a/tools/htseq.wdl
+++ b/tools/htseq.wdl
@@ -11,7 +11,7 @@ task count {
         File gtf
         String provided_strand
         String inferred_strand
-        String outfile = basename(bam, ".bam") + ".counts.txt"
+        String outfile = basename(bam, ".bam") + ".feature-counts.txt"
         Int added_memory_gb = 20
         Int max_retries = 1
     }


### PR DESCRIPTION
Changing HTSeq file output suffix to *.feature-counts.txt to match existing St. Jude Cloud feature count file format