### PR TITLE
refactor: use samtools quickcheck to do initial validation

### DIFF
--- a/tools/multiqc.wdl
+++ b/tools/multiqc.wdl
@@ -86,7 +86,6 @@ task multiqc {
     }
 
     parameter_meta {
-        bam: "The BAM referenced by other input reports"
         validate_sam_file: "A file output from Picard's ValidateSam tool"
         qualimap_bamqc: "Tarballed directory of files output by Qualimap's BamQC mode"
         qualimap_rnaseq: "Tarballed directory of files output by Qualimap's RNA-seq mode"

--- a/tools/multiqc.wdl
+++ b/tools/multiqc.wdl
@@ -19,7 +19,7 @@ task multiqc {
         Int disk_size = 20
     }
 
-    String out_directory = basename(bam, ".ValidateSamFile.txt") + "_multiqc"
+    String out_directory = basename(validate_sam_file, ".ValidateSamFile.txt") + "_multiqc"
     String out_tar_gz = out_directory + ".tar.gz"
 
     command {

--- a/tools/multiqc.wdl
+++ b/tools/multiqc.wdl
@@ -7,7 +7,6 @@ version 1.0
 
 task multiqc {
     input {
-        File bam
         File validate_sam_file
         File qualimap_bamqc
         File? qualimap_rnaseq
@@ -17,12 +16,11 @@ task multiqc {
         File? star_log
         Int max_retries = 1
         Int memory_gb = 5
+        Int disk_size = 20
     }
 
-    String out_directory = basename(bam, ".bam") + "_multiqc"
+    String out_directory = basename(bam, ".ValidateSamFile.txt") + "_multiqc"
     String out_tar_gz = out_directory + ".tar.gz"
-    Float bam_size = size(bam, "GiB")
-    Int disk_size = ceil((bam_size * 2) + 10)
 
     command {
         set -eo pipefail
@@ -31,8 +29,7 @@ task multiqc {
         export LC_ALL=C.UTF-8
         export LANG=C.UTF-8
         
-        echo ~{bam} > file_list.txt
-        echo ~{validate_sam_file} >> file_list.txt
+        echo ~{validate_sam_file} > file_list.txt
         echo ~{flagstat_file} >> file_list.txt
 
         qualimap_bamqc_dir=$(basename ~{qualimap_bamqc} ".tar.gz")

--- a/tools/multiqc.wdl
+++ b/tools/multiqc.wdl
@@ -22,7 +22,7 @@ task multiqc {
     String out_directory = basename(bam, ".bam") + "_multiqc"
     String out_tar_gz = out_directory + ".tar.gz"
     Float bam_size = size(bam, "GiB")
-    Int disk_size = ceil((bam_size * 1.2) + 10)
+    Int disk_size = ceil((bam_size * 2) + 10)
 
     command {
         set -eo pipefail

--- a/tools/multiqc.wdl
+++ b/tools/multiqc.wdl
@@ -7,7 +7,7 @@ version 1.0
 
 task multiqc {
     input {
-        File sorted_bam
+        File bam
         File validate_sam_file
         File qualimap_bamqc
         File? qualimap_rnaseq
@@ -19,10 +19,10 @@ task multiqc {
         Int memory_gb = 5
     }
 
-    String out_directory = basename(sorted_bam, ".bam") + "_multiqc"
+    String out_directory = basename(bam, ".bam") + "_multiqc"
     String out_tar_gz = out_directory + ".tar.gz"
-    Float star_size = size(sorted_bam, "GiB")
-    Int disk_size = ceil((star_size * 4) + 10)
+    Float bam_size = size(bam, "GiB")
+    Int disk_size = ceil((bam_size * 1.2) + 10)
 
     command {
         set -eo pipefail
@@ -31,7 +31,7 @@ task multiqc {
         export LC_ALL=C.UTF-8
         export LANG=C.UTF-8
         
-        echo ~{sorted_bam} > file_list.txt
+        echo ~{bam} > file_list.txt
         echo ~{validate_sam_file} >> file_list.txt
         echo ~{flagstat_file} >> file_list.txt
 
@@ -89,11 +89,13 @@ task multiqc {
     }
 
     parameter_meta {
-        sorted_bam: "A aligned, sorted BAM file"
+        bam: "The BAM referenced by other input reports"
         validate_sam_file: "A file output from Picard's ValidateSam tool"
         qualimap_bamqc: "Tarballed directory of files output by Qualimap's BamQC mode"
         qualimap_rnaseq: "Tarballed directory of files output by Qualimap's RNA-seq mode"
         fastqc: "Tarballed directory of files output by FastQC"
-        flagstat_file: "A file containing the output of Samtools' flagstat command for the input STAR aligned BAM file"
+        fastq_screen: "Tarballed directory of files output by FastQ Screen"
+        flagstat_file: "A file containing the output of Samtools' flagstat command for the input BAM file"
+        star_log: "The log file of a STAR alignment run"
     }
 }

--- a/tools/samtools.wdl
+++ b/tools/samtools.wdl
@@ -24,6 +24,10 @@ task quickcheck {
         maxRetries: max_retries
     }
 
+    output {
+        File checked_bam = bam
+    }
+
     meta {
         author: "Andrew Thrasher, Andrew Frantz"
         email: "andrew.thrasher@stjude.org, andrew.frantz@stjude.org"

--- a/workflows/qc/quality-check-standard.wdl
+++ b/workflows/qc/quality-check-standard.wdl
@@ -98,7 +98,6 @@ workflow quality_check {
         
         call mqc.multiqc {
             input:
-                bam=quickcheck.checked_bam,
                 validate_sam_file=validate_bam.out,
                 flagstat_file=samtools_flagstat.outfile,
                 fastqc=fastqc.results,
@@ -115,7 +114,6 @@ workflow quality_check {
         
         call mqc.multiqc as multiqc_rnaseq {
             input:
-                bam=quickcheck.checked_bam,
                 validate_sam_file=validate_bam.out,
                 star_log=star_log,
                 flagstat_file=samtools_flagstat.outfile,

--- a/workflows/qc/quality-check-standard.wdl
+++ b/workflows/qc/quality-check-standard.wdl
@@ -98,7 +98,7 @@ workflow quality_check {
         
         call mqc.multiqc {
             input:
-                sorted_bam=quickcheck.checked_bam,
+                bam=quickcheck.checked_bam,
                 validate_sam_file=validate_bam.out,
                 flagstat_file=samtools_flagstat.outfile,
                 fastqc=fastqc.results,
@@ -115,7 +115,7 @@ workflow quality_check {
         
         call mqc.multiqc as multiqc_rnaseq {
             input:
-                sorted_bam=quickcheck.checked_bam,
+                bam=quickcheck.checked_bam,
                 validate_sam_file=validate_bam.out,
                 star_log=star_log,
                 flagstat_file=samtools_flagstat.outfile,

--- a/workflows/qc/quality-check-standard.wdl
+++ b/workflows/qc/quality-check-standard.wdl
@@ -35,7 +35,7 @@ import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/ngs
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/qualimap.wdl"
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/fq.wdl"
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/fastq_screen.wdl" as fq_screen
-import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/multiqc.wdl" as mqc
+import "https://raw.githubusercontent.com/stjudecloud/workflows/validate-refactor/tools/multiqc.wdl" as mqc
 
 workflow quality_check {
     input {

--- a/workflows/qc/quality-check-standard.wdl
+++ b/workflows/qc/quality-check-standard.wdl
@@ -29,7 +29,7 @@ version 1.0
 
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/md5sum.wdl"
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/picard.wdl"
-import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/samtools.wdl"
+import "https://raw.githubusercontent.com/stjudecloud/workflows/validate-refactor/tools/samtools.wdl"
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/fastqc.wdl" as fqc
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/ngsderive.wdl"
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/qualimap.wdl"
@@ -64,6 +64,7 @@ workflow quality_check {
         max_retries: "Number of times to retry failed steps"
     }
 
+    String prefix = basename(bam, ".bam")
     String provided_strandedness = strandedness
 
     call parse_input {
@@ -77,27 +78,27 @@ workflow quality_check {
     call md5sum.compute_checksum { input: infile=bam, max_retries=max_retries }
 
     call picard.validate_bam { input: bam=bam, summary_mode=true, max_retries=max_retries }
-    String prefix = basename(validate_bam.validated_bam, ".bam")
+    call samtools.quickcheck { input: bam=bam, max_retries=max_retries }
 
-    call samtools.flagstat as samtools_flagstat { input: bam=validate_bam.validated_bam, max_retries=max_retries }
-    call fqc.fastqc { input: bam=validate_bam.validated_bam, max_retries=max_retries }
-    call ngsderive.instrument as ngsderive_instrument { input: bam=validate_bam.validated_bam, max_retries=max_retries }
-    call ngsderive.read_length as ngsderive_read_length { input: bam=validate_bam.validated_bam, bai=bam_index, max_retries=max_retries }
-    call ngsderive.encoding as ngsderive_encoding { input: ngs_files=[validate_bam.validated_bam], prefix=prefix, max_retries=max_retries }
-    call qualimap.bamqc as qualimap_bamqc { input: bam=validate_bam.validated_bam, max_retries=max_retries }
+    call samtools.flagstat as samtools_flagstat { input: bam=quickcheck.checked_bam, max_retries=max_retries }
+    call fqc.fastqc { input: bam=quickcheck.checked_bam, max_retries=max_retries }
+    call ngsderive.instrument as ngsderive_instrument { input: bam=quickcheck.checked_bam, max_retries=max_retries }
+    call ngsderive.read_length as ngsderive_read_length { input: bam=quickcheck.checked_bam, bai=bam_index, max_retries=max_retries }
+    call ngsderive.encoding as ngsderive_encoding { input: ngs_files=[quickcheck.checked_bam], prefix=prefix, max_retries=max_retries }
+    call qualimap.bamqc as qualimap_bamqc { input: bam=quickcheck.checked_bam, max_retries=max_retries }
 
     if (experiment == "WGS" || experiment == "WES") {
         File fastq_screen_db_defined = select_first([fastq_screen_db, "No DB"])
 
-        call samtools.subsample as samtools_subsample { input: bam=validate_bam.validated_bam, max_retries=max_retries }
+        call samtools.subsample as samtools_subsample { input: bam=quickcheck.checked_bam, max_retries=max_retries }
         call picard.bam_to_fastq { input: bam=samtools_subsample.sampled_bam, max_retries=max_retries }
         call fq.fqlint { input: read1=bam_to_fastq.read1, read2=bam_to_fastq.read2, max_retries=max_retries }
 
-        call fq_screen.fastq_screen as fastq_screen { input: read1=fqlint.validated_read1, read2=fqlint.validated_read2, db=fastq_screen_db_defined, provided_encoding=phred_encoding, inferred_encoding=ngsderive_encoding.inferred_encoding, max_retries=max_retries }
+        call fq_screen.fastq_screen { input: read1=fqlint.validated_read1, read2=fqlint.validated_read2, db=fastq_screen_db_defined, provided_encoding=phred_encoding, inferred_encoding=ngsderive_encoding.inferred_encoding, max_retries=max_retries }
         
         call mqc.multiqc {
             input:
-                sorted_bam=validate_bam.validated_bam,
+                sorted_bam=quickcheck.checked_bam,
                 validate_sam_file=validate_bam.out,
                 flagstat_file=samtools_flagstat.outfile,
                 fastqc=fastqc.results,
@@ -109,12 +110,12 @@ workflow quality_check {
     if (experiment == "RNA-Seq") {
         File gencode_gtf_defined = select_first([gencode_gtf, "No GTF"])
 
-        call ngsderive.infer_strandedness as ngsderive_strandedness { input: bam=validate_bam.validated_bam, bai=bam_index, gtf=gencode_gtf_defined, max_retries=max_retries }
-        call qualimap.rnaseq as qualimap_rnaseq { input: bam=validate_bam.validated_bam, gencode_gtf=gencode_gtf_defined, provided_strandedness=provided_strandedness, inferred_strandedness=ngsderive_strandedness.strandedness, paired_end=paired_end, max_retries=max_retries }
+        call ngsderive.infer_strandedness as ngsderive_strandedness { input: bam=quickcheck.checked_bam, bai=bam_index, gtf=gencode_gtf_defined, max_retries=max_retries }
+        call qualimap.rnaseq as qualimap_rnaseq { input: bam=quickcheck.checked_bam, gencode_gtf=gencode_gtf_defined, provided_strandedness=provided_strandedness, inferred_strandedness=ngsderive_strandedness.strandedness, paired_end=paired_end, max_retries=max_retries }
         
         call mqc.multiqc as multiqc_rnaseq {
             input:
-                sorted_bam=validate_bam.validated_bam,
+                sorted_bam=quickcheck.checked_bam,
                 validate_sam_file=validate_bam.out,
                 star_log=star_log,
                 flagstat_file=samtools_flagstat.outfile,

--- a/workflows/qc/quality-check-standard.wdl
+++ b/workflows/qc/quality-check-standard.wdl
@@ -29,13 +29,13 @@ version 1.0
 
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/md5sum.wdl"
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/picard.wdl"
-import "https://raw.githubusercontent.com/stjudecloud/workflows/validate-refactor/tools/samtools.wdl"
+import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/samtools.wdl"
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/fastqc.wdl" as fqc
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/ngsderive.wdl"
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/qualimap.wdl"
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/fq.wdl"
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/fastq_screen.wdl" as fq_screen
-import "https://raw.githubusercontent.com/stjudecloud/workflows/validate-refactor/tools/multiqc.wdl" as mqc
+import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/multiqc.wdl" as mqc
 
 workflow quality_check {
     input {


### PR DESCRIPTION
For large BAMs `picard validate` can take multiple hours, preventing any other tools from running. This adds `samtools quickcheck` to do a precursory validation before other tools run as opposed to waiting for the complete `picard validate`.