### PR TITLE
Update WDL tasks to comply with dxCompiler restrictions

### DIFF
--- a/tools/bwa.wdl
+++ b/tools/bwa.wdl
@@ -196,7 +196,7 @@ task bwa_mem {
     }
 }
 
-task build_db {
+task build_bwa_db {
     input {
         File reference_fasta
         String bwadb_out_name = "bwadb.tar.gz"

--- a/tools/fq.wdl
+++ b/tools/fq.wdl
@@ -15,7 +15,7 @@ task fqlint {
     }
 
     Float read1_size = size(read1, "GiB")
-    Float read2_size = if defined(read2) then size(read2, "GiB") else "0"
+    Float read2_size = if defined(read2) then size(read2, "GiB") else 0
     Int disk_size = ceil(((read1_size + read2_size) * 2) + 10)
     String args = if defined(read2) then "" else "--disable-validator P001" 
 

--- a/tools/star.wdl
+++ b/tools/star.wdl
@@ -5,7 +5,7 @@
 
 version 1.0
 
-task build_db {
+task build_star_db {
     input {
         Int ncpu = 1
         File reference_fasta
@@ -97,6 +97,7 @@ task alignment {
     Float read_two_fastqs_size = size(select_first([read_two_fastqs, []]), "GiB")
     Float stardb_tar_gz_size = size(stardb_tar_gz, "GiB")
     Int disk_size = select_first([disk_size_gb, ceil(((read_one_fastqs_size + read_two_fastqs_size + stardb_tar_gz_size) * 3) + 10)])
+    Array[File] r2_fastqs = select_first([read_two_fastqs, []])
 
     command {
         set -euo pipefail
@@ -115,7 +116,7 @@ task alignment {
             then
                 python /home/sort_star_input.py \
                     --read_one_fastqs "~{sep=',' read_one_fastqs}" \
-                    --read_two_fastqs "~{sep=',' read_two_fastqs}" \
+                    --read_two_fastqs "~{sep=',' r2_fastqs}" \
                     --read_groups "~{read_groups}"
             else
                 python /home/sort_star_input.py \
@@ -127,7 +128,7 @@ task alignment {
             then
                 python /home/sort_star_input.py \
                     --read_one_fastqs "~{sep=',' read_one_fastqs}" \
-                    --read_two_fastqs "~{sep=',' read_two_fastqs}"
+                    --read_two_fastqs "~{sep=',' r2_fastqs}"
             else
                 python /home/sort_star_input.py \
                     --read_one_fastqs "~{sep=',' read_one_fastqs}"

--- a/workflows/chipseq/chipseq-bwa-db-build.wdl
+++ b/workflows/chipseq/chipseq-bwa-db-build.wdl
@@ -48,7 +48,7 @@ workflow bwa_db_build {
     }
 
     call util.download as reference_download { input: url=reference_fa_url, outfilename=reference_fa_name }
-    call bwa.build_bwa_db as build_bwa_db {
+    call bwa.build_bwa_db {
         input:
             reference_fasta=reference_download.outfile,
             bwadb_out_name="bwadb.tar.gz",

--- a/workflows/chipseq/chipseq-bwa-db-build.wdl
+++ b/workflows/chipseq/chipseq-bwa-db-build.wdl
@@ -48,7 +48,7 @@ workflow bwa_db_build {
     }
 
     call util.download as reference_download { input: url=reference_fa_url, outfilename=reference_fa_name }
-    call bwa.build_db as build_bwa_db {
+    call bwa.build_bwa_db as build_bwa_db {
         input:
             reference_fasta=reference_download.outfile,
             bwadb_out_name="bwadb.tar.gz",

--- a/workflows/chipseq/chipseq-standard.wdl
+++ b/workflows/chipseq/chipseq-standard.wdl
@@ -117,7 +117,7 @@ workflow chipseq_standard {
     #     }
     # }
 
-    Array[File] aligned_bams = select_first([single_end.tagged_bam, ""])#paired_end.bam])
+    Array[File] aligned_bams = select_first([single_end.tagged_bam, []])#paired_end.bam])
 
     scatter(bam in aligned_bams){
        call picard.clean_sam as picard_clean { input: bam=bam }

--- a/workflows/general/bwa-db-build.wdl
+++ b/workflows/general/bwa-db-build.wdl
@@ -48,7 +48,7 @@ workflow bwa_db_build {
     }
 
     call util.download as reference_download { input: url=reference_fa_url, outfilename=reference_fa_name }
-    call bwa.build_db {
+    call bwa.build_bwa_db as build_db {
         input:
             reference_fasta=reference_download.outfile,
             bwadb_out_name="bwa.tar.gz"

--- a/workflows/general/bwa-db-build.wdl
+++ b/workflows/general/bwa-db-build.wdl
@@ -48,7 +48,7 @@ workflow bwa_db_build {
     }
 
     call util.download as reference_download { input: url=reference_fa_url, outfilename=reference_fa_name }
-    call bwa.build_bwa_db as build_db {
+    call bwa.build_bwa_db {
         input:
             reference_fasta=reference_download.outfile,
             bwadb_out_name="bwa.tar.gz"
@@ -56,6 +56,6 @@ workflow bwa_db_build {
 
     output {
       File reference_fa = reference_download.outfile
-      File bwadb_tar_gz = build_db.bwadb_tar_gz
+      File bwadb_tar_gz = build_bwa_db.bwadb_tar_gz
     }
 }

--- a/workflows/rnaseq/rnaseq-star-db-build.wdl
+++ b/workflows/rnaseq/rnaseq-star-db-build.wdl
@@ -56,7 +56,7 @@ workflow rnaseq_star_db_build {
 
     call util.download as reference_download { input: url=reference_fa_url, outfilename=reference_fa_name }
     call util.download as gtf_download { input: url=gtf_url, outfilename=gtf_name }
-    call star.build_db as star_db_build {
+    call star.build_star_db as star_db_build {
         input:
             reference_fasta=reference_download.outfile,
             gtf=gtf_download.outfile,

--- a/workflows/rnaseq/rnaseq-star-db-build.wdl
+++ b/workflows/rnaseq/rnaseq-star-db-build.wdl
@@ -56,7 +56,7 @@ workflow rnaseq_star_db_build {
 
     call util.download as reference_download { input: url=reference_fa_url, outfilename=reference_fa_name }
     call util.download as gtf_download { input: url=gtf_url, outfilename=gtf_name }
-    call star.build_star_db as star_db_build {
+    call star.build_star_db {
         input:
             reference_fasta=reference_download.outfile,
             gtf=gtf_download.outfile,
@@ -67,6 +67,6 @@ workflow rnaseq_star_db_build {
     output {
       File reference_fa = reference_download.outfile
       File gtf = gtf_download.outfile
-      File stardb_tar_gz = star_db_build.stardb_out
+      File stardb_tar_gz = build_star_db.stardb_out
     }
 }


### PR DESCRIPTION
To support a user, we want to be able to use rnaseq-standard-fastq with dxCompiler. dxCompiler sets stricter requirements than miniwdl or cromwell. This PR addresses those requirements.