### PR TITLE
feat: compute and output md5 checksum for all BAM alignment workflows

### DIFF
--- a/workflows/chipseq/chipseq-standard.wdl
+++ b/workflows/chipseq/chipseq-standard.wdl
@@ -129,10 +129,13 @@ workflow chipseq_standard {
     call samtools.index as samtools_index { input: bam=markdup.mkdupbam, max_retries=max_retries, detect_nproc=detect_nproc }
     call picard.validate_bam { input: bam=markdup.mkdupbam, max_retries=max_retries }
 
+    call md5sum.compute_checksum { input: infile=markdup.mkdupbam, max_retries=max_retries }
+
     call deeptools.bamCoverage as deeptools_bamCoverage { input: bam=markdup.mkdupbam, bai=samtools_index.bai, prefix=output_prefix, max_retries=max_retries }
 
     output {
         File bam = markdup.mkdupbam
+        File bam_checksum = compute_checksum.outfile
         File bam_index = samtools_index.bai
         File bigwig = deeptools_bamCoverage.bigwig
     }

--- a/workflows/rnaseq/rnaseq-standard-fastq.wdl
+++ b/workflows/rnaseq/rnaseq-standard-fastq.wdl
@@ -99,11 +99,14 @@ workflow rnaseq_standard_fastq {
     File aligned_bam = select_first([xenocp.bam, picard_sort.sorted_bam])
     File aligned_bai = select_first([xenocp.bam_index, samtools_index.bai])
 
+    call md5sum.compute_checksum { input: infile=aligned_bam, max_retries=max_retries }
+
     call htseq.count as htseq_count { input: bam=aligned_bam, gtf=gtf, provided_strandedness=provided_strandedness, inferred_strandedness=parsed_strandedness, max_retries=max_retries }
     call deeptools.bamCoverage as deeptools_bamCoverage { input: bam=aligned_bam, bai=aligned_bai, max_retries=max_retries }
 
     output {
         File bam = aligned_bam
+        File bam_checksum = compute_checksum.outfile
         File bam_index = aligned_bai
         File star_log = alignment.star_log
         File gene_counts = htseq_count.out

--- a/workflows/rnaseq/rnaseq-standard.wdl
+++ b/workflows/rnaseq/rnaseq-standard.wdl
@@ -116,11 +116,14 @@ workflow rnaseq_standard {
     File aligned_bam = select_first([xenocp.bam, picard_sort.sorted_bam])
     File aligned_bai = select_first([xenocp.bam_index, samtools_index.bai])
 
+    call md5sum.compute_checksum { input: infile=aligned_bam, max_retries=max_retries }
+
     call htseq.count as htseq_count { input: bam=aligned_bam, gtf=gtf, provided_strandedness=provided_strandedness, inferred_strandedness=parsed_strandedness, max_retries=max_retries }
     call deeptools.bamCoverage as deeptools_bamCoverage { input: bam=aligned_bam, bai=aligned_bai, max_retries=max_retries }
 
     output {
         File bam = aligned_bam
+        File bam_checksum = compute_checksum.outfile
         File bam_index = aligned_bai
         File star_log = alignment.star_log
         File gene_counts = htseq_count.out

--- a/workflows/scrnaseq/scrnaseq-standard.wdl
+++ b/workflows/scrnaseq/scrnaseq-standard.wdl
@@ -93,8 +93,11 @@ workflow scrnaseq_standard {
     call ngsderive.infer_strandedness as ngsderive_strandedness { input: bam=count.bam, bai=count.bam_index, gtf=gtf, max_retries=max_retries }
     String parsed_strandedness = read_string(ngsderive_strandedness.strandedness)
 
+    call md5sum.compute_checksum { input: infile=count.bam, max_retries=max_retries }
+
     output {
         File bam = count.bam
+        File bam_checksum = compute_checksum.outfile
         File bam_index = count.bam_index
         File qc = count.qc
         File barcodes = count.barcodes


### PR DESCRIPTION
During a discussion about how QC calculates and outputs an MD5 sum that's never used by our broader pipelines, me and @adthrasher agreed that *all* our WDL workflows should be producing MD5 sums and we should be validating them at various points. This change sets us up to be more proactive about detecting corruption (the next step would be actually using these MD5s).