### PR TITLE
Name sort

### DIFF
--- a/tools/qualimap.wdl
+++ b/tools/qualimap.wdl
@@ -65,12 +65,13 @@ task rnaseq {
     input {
         File bam
         File gtf
-        Int memory_gb = 16
-        Int? disk_size_gb
-        Int max_retries = 1
+        Boolean name_sorted = false
         Boolean paired_end = false
         String provided_strandedness = ""
         String inferred_strandedness = ""
+        Int memory_gb = 16
+        Int? disk_size_gb
+        Int max_retries = 1
     }
 
     String out_directory = basename(bam, ".bam") + ".qualimap_rnaseq_results"
@@ -86,6 +87,7 @@ task rnaseq {
                         if (inferred_strandedness == "Unstranded") then "non-strand-specific" else
                         "unknown-strand" # this will intentionally cause qualimap to error. You will need to manually specify
                                          # in this case
+    String name_sorted_arg = if (name_sorted) then "-s" else ""
     String paired_end_arg = if (paired_end) then "-pe" else ""
 
     Int java_heap_size = ceil(memory_gb * 0.9)
@@ -105,6 +107,7 @@ task rnaseq {
                         -outdir ~{out_directory} \
                         -oc qualimap_counts.txt \
                         -p ~{stranded} \
+                        ~{name_sorted_arg} \
                         ~{paired_end_arg} \
                         --java-mem-size=~{java_heap_size}G
         rm "$gtf_name"

--- a/workflows/qc/quality-check-standard.wdl
+++ b/workflows/qc/quality-check-standard.wdl
@@ -32,7 +32,7 @@ import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/pic
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/samtools.wdl"
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/fastqc.wdl" as fqc
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/ngsderive.wdl"
-import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/qualimap.wdl"
+import "https://raw.githubusercontent.com/stjudecloud/workflows/name_sort/tools/qualimap.wdl"
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/fq.wdl"
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/fastq_screen.wdl" as fq_screen
 import "https://raw.githubusercontent.com/stjudecloud/workflows/master/tools/sequencerr.wdl"

--- a/workflows/qc/quality-check-standard.wdl
+++ b/workflows/qc/quality-check-standard.wdl
@@ -118,7 +118,9 @@ workflow quality_check {
 
         call ngsderive.infer_strandedness as ngsderive_strandedness { input: bam=quickcheck.checked_bam, bai=bam_index, gtf=gtf_defined, max_retries=max_retries }
         String parsed_strandedness = read_string(ngsderive_strandedness.strandedness)
-        call qualimap.rnaseq as qualimap_rnaseq { input: bam=quickcheck.checked_bam, gtf=gtf_defined, provided_strandedness=provided_strandedness, inferred_strandedness=parsed_strandedness, paired_end=paired_end, max_retries=max_retries }
+
+        call picard.sort as picard_sort { input: bam=quickcheck.checked_bam, sort_order="queryname", max_retries=max_retries }
+        call qualimap.rnaseq as qualimap_rnaseq { input: bam=picard_sort.sorted_bam, gtf=gtf_defined, provided_strandedness=provided_strandedness, inferred_strandedness=parsed_strandedness, name_sorted=true, paired_end=paired_end, max_retries=max_retries }
     }
 
     call mqc.multiqc {


### PR DESCRIPTION
I was hoping `picard sort` would be faster than Qualimap's sorting, but no noticeable difference in speed. However this did remove the transient failure I was seeing earlier (at least removed for my test cohort of 81 samples. I wouldn't be shocked if it comes back with a larger pool of samples). This change will get us a slight improvement in stability, but nothing earth shattering.