### PR TITLE
feat(fq): expose lint options

### DIFF
--- a/tools/bwa.wdl
+++ b/tools/bwa.wdl
@@ -20,7 +20,7 @@ task bwa_aln {
         File bwa_db_tar_gz
         String prefix = sub(
             basename(fastq),
-            "([_\.]R[12])?(\.subsampled)?\.(fastq|fq)(\.gz)?$",
+            "([_\.][rR][12])?(\.subsampled)?\.(fastq|fq)(\.gz)?$",
             ""
         )
         String read_group = ""
@@ -94,7 +94,7 @@ task bwa_aln_pe {
         File bwa_db_tar_gz
         String prefix = sub(
             basename(read_one_fastq_gz),
-            "([_\.]R[12])?(\.subsampled)?\.(fastq|fq)(\.gz)?$",
+            "([_\.][rR][12])?(\.subsampled)?\.(fastq|fq)(\.gz)?$",
             ""
         )
         String read_group = ""
@@ -169,7 +169,7 @@ task bwa_mem {
         File bwa_db_tar_gz
         String prefix = sub(
             basename(fastq),
-            "([_\.]R[12])?(\.subsampled)?\.(fastq|fq)(\.gz)?$",
+            "([_\.][rR][12])?(\.subsampled)?\.(fastq|fq)(\.gz)?$",
             ""
         )
         String read_group = ""

--- a/tools/fq.wdl
+++ b/tools/fq.wdl
@@ -12,8 +12,8 @@ task fqlint {
     }
 
     parameter_meta {
-        read_one_fastq: "Input FASTQ with read one"
-        read_two_fastq: "Input FASTQ with read two"
+        read_one_fastq: "Input FASTQ with read one. Can be gzipped or uncompressed."
+        read_two_fastq: "Input FASTQ with read two. Can be gzipped or uncompressed."
         disable_validator_codes: {
             description: "Array of codes to disable specific validators",
             choices: {
@@ -103,8 +103,8 @@ task subsample {
     }
 
     parameter_meta {
-        read_one_fastq: "Input FASTQ with read one"
-        read_two_fastq: "Input FASTQ with read two"
+        read_one_fastq: "Input FASTQ with read one. Can be gzipped or uncompressed."
+        read_two_fastq: "Input FASTQ with read two. Can be gzipped or uncompressed."
         prefix: "Prefix for the output FASTQ file(s). The extension `_R1.subsampled.fastq.gz` and `_R2.subsampled.fastq.gz` will be added."
         probability: "The probability a record is kept, as a decimal (0.0, 1.0). Cannot be used with `record-count`. Any `probability<=0.0` or `probability>=1.0` to disable."
         record_count: "The exact number of records to keep. Cannot be used with `probability`. Any `record_count<=0` to disable."

--- a/tools/fq.wdl
+++ b/tools/fq.wdl
@@ -80,7 +80,7 @@ task subsample {
         File? read_two_fastq_gz
         String prefix = sub(
             basename(read_one_fastq_gz),
-            "([_\.]R[12])?(\.subsampled)?\.(fastq|fq)(\.gz)?$",
+            "([_\.][rR][12])?(\.subsampled)?\.(fastq|fq)(\.gz)?$",
             ""
         )
         Float probability = 1.0

--- a/tools/fq.wdl
+++ b/tools/fq.wdl
@@ -12,20 +12,20 @@ task fqlint {
     }
 
     parameter_meta {
-        read_one_fastq_gz: "Input FASTQ with read one"
-        read_two_fastq_gz: "Input FASTQ with read two"
+        read_one_fastq: "Input FASTQ with read one"
+        read_two_fastq: "Input FASTQ with read two"
     }
 
     input {
-        File read_one_fastq_gz
-        File? read_two_fastq_gz
+        File read_one_fastq
+        File? read_two_fastq
         Int modify_memory_gb = 0
         Int modify_disk_size_gb = 0
         Int max_retries = 1
     }
 
-    Float read1_size = size(read_one_fastq_gz, "GiB")
-    Float read2_size = size(read_two_fastq_gz, "GiB")
+    Float read1_size = size(read_one_fastq, "GiB")
+    Float read2_size = size(read_two_fastq, "GiB")
 
     Int memory_gb_calculation = (
         ceil((read1_size + read2_size) * 0.12) + modify_memory_gb
@@ -43,8 +43,8 @@ task fqlint {
     >>>
 
     output {
-        File validated_read1 = read_one_fastq_gz
-        File? validated_read2 = read_two_fastq_gz
+        File validated_read1 = read_one_fastq
+        File? validated_read2 = read_two_fastq
     }
 
     runtime {
@@ -65,8 +65,8 @@ task subsample {
     }
 
     parameter_meta {
-        read_one_fastq_gz: "Input FASTQ with read one"
-        read_two_fastq_gz: "Input FASTQ with read two"
+        read_one_fastq: "Input FASTQ with read one"
+        read_two_fastq: "Input FASTQ with read two"
         prefix: "Prefix for the output FASTQ file(s). The extension `_R1.subsampled.fastq.gz` and `_R2.subsampled.fastq.gz` will be added."
         probability: "The probability a record is kept, as a decimal (0.0, 1.0). Cannot be used with `record-count`. Any `probability<=0.0` or `probability>=1.0` to disable."
         record_count: "The exact number of records to keep. Cannot be used with `probability`. Any `record_count<=0` to disable."
@@ -76,10 +76,10 @@ task subsample {
     }
 
     input {
-        File read_one_fastq_gz
-        File? read_two_fastq_gz
+        File read_one_fastq
+        File? read_two_fastq
         String prefix = sub(
-            basename(read_one_fastq_gz),
+            basename(read_one_fastq),
             "([_\.][rR][12])?(\.subsampled)?\.(fastq|fq)(\.gz)?$",
             ""
         )
@@ -90,8 +90,8 @@ task subsample {
         Int max_retries = 1
     }
 
-    Float read1_size = size(read_one_fastq_gz, "GiB")
-    Float read2_size = size(read_two_fastq_gz, "GiB")
+    Float read1_size = size(read_one_fastq, "GiB")
+    Float read2_size = size(read_two_fastq, "GiB")
 
     Int disk_size_gb = ceil((read1_size + read2_size) * 2) + modify_disk_size_gb
 
@@ -108,12 +108,12 @@ task subsample {
             ~{probability_arg} \
             ~{record_count_arg} \
             --r1-dst ~{r1_dst} \
-            ~{if defined(read_two_fastq_gz)
+            ~{if defined(read_two_fastq)
                 then "--r2-dst " + r2_dst
                 else ""
             } \
-            ~{read_one_fastq_gz} \
-            ~{read_two_fastq_gz}
+            ~{read_one_fastq} \
+            ~{read_two_fastq}
     >>>
 
     output {

--- a/tools/kraken.wdl
+++ b/tools/kraken.wdl
@@ -309,7 +309,7 @@ task kraken {
         File db
         String prefix = sub(
             basename(read_one_fastq_gz),
-            "([_\.]R[12])?(\.subsampled)?\.(fastq|fq)(\.gz)?$",
+            "([_\.][rR][12])?(\.subsampled)?\.(fastq|fq)(\.gz)?$",
             ""
         )
         Boolean store_sequences = false

--- a/workflows/general/bam-to-fastqs.wdl
+++ b/workflows/general/bam-to-fastqs.wdl
@@ -68,8 +68,8 @@ workflow bam_to_fastqs {
         zip(bam_to_fastq.read_one_fastq_gz, bam_to_fastq.read_two_fastq_gz)
     ) {
         call fq.fqlint { input:
-            read_one_fastq_gz=select_first([reads.left, "undefined"]),
-            read_two_fastq_gz=reads.right,
+            read_one_fastq=select_first([reads.left, "undefined"]),
+            read_two_fastq=reads.right,
             max_retries=max_retries
         }
     }

--- a/workflows/qc/quality-check-standard.wdl
+++ b/workflows/qc/quality-check-standard.wdl
@@ -198,8 +198,8 @@ workflow quality_check {
     }
 
     call fq.fqlint { input:
-        read_one_fastq_gz=select_first([collate_to_fastq.read_one_fastq_gz, "undefined"]),
-        read_two_fastq_gz=collate_to_fastq.read_two_fastq_gz,
+        read_one_fastq=select_first([collate_to_fastq.read_one_fastq_gz, "undefined"]),
+        read_two_fastq=collate_to_fastq.read_two_fastq_gz,
         max_retries=max_retries
     }
     call kraken2.kraken { input:

--- a/workflows/rnaseq/rnaseq-standard-fastq.wdl
+++ b/workflows/rnaseq/rnaseq-standard-fastq.wdl
@@ -93,8 +93,8 @@ workflow rnaseq_standard_fastq {
     if (validate_input){
         scatter (reads in zip(read_one_fastqs, read_two_fastqs)) {
             call fq.fqlint { input:
-                read_one_fastq_gz=reads.left,
-                read_two_fastq_gz=reads.right,
+                read_one_fastq=reads.left,
+                read_two_fastq=reads.right,
                 max_retries=max_retries
             }
         }
@@ -104,8 +104,8 @@ workflow rnaseq_standard_fastq {
         Int reads_per_pair = ceil(subsample_n_reads / length(read_one_fastqs))
         scatter (reads in zip(read_one_fastqs, read_two_fastqs)) {
             call fq.subsample { input:
-                read_one_fastq_gz=reads.left,
-                read_two_fastq_gz=reads.right,
+                read_one_fastq=reads.left,
+                read_two_fastq=reads.right,
                 record_count=reads_per_pair,
                 max_retries=max_retries
             }

--- a/workflows/scrnaseq/10x-bam-to-fastqs.wdl
+++ b/workflows/scrnaseq/10x-bam-to-fastqs.wdl
@@ -75,8 +75,8 @@ workflow cell_ranger_bam_to_fastqs {
     }
     scatter (reads in zip(bamtofastq.read_one_fastq_gz, bamtofastq.read_two_fastq_gz)) {
         call fq.fqlint { input:
-            read_one_fastq_gz=reads.left,
-            read_two_fastq_gz=reads.right,
+            read_one_fastq=reads.left,
+            read_two_fastq=reads.right,
             max_retries=max_retries
         }
     }


### PR DESCRIPTION
In addition to exposing `fq lint` options, there are 2 other minor changes.
1) All `read_*_fastq_gz` input variables to `fq` tasks have had the `_gz` suffix dropped. `fq` accepts raw input as well, and auto detects which the file is.
2) The `basename()` regex for FASTQ files that is used in multiple files has been updated to catch lowercase `_r1`/`_r2` extensions.