### PR TITLE
feat: librarian

### DIFF
--- a/tests/tools/test_librarian.yaml
+++ b/tests/tools/test_librarian.yaml
@@ -1,0 +1,9 @@
+- name: librarian
+  tags:
+    - miniwdl
+    - librarian
+  command: >-
+    miniwdl run -d test-output/. --task librarian tools/librarian.wdl read_one_fastq="tests/tools/input/test_R1.fq.gz"
+  files:
+    - path: test-output/out/report/test_R1.librarian.tar.gz
+    - path: test-output/out/raw_data/librarian_heatmap.txt

--- a/tests/tools/test_librarian.yaml
+++ b/tests/tools/test_librarian.yaml
@@ -5,5 +5,5 @@
   command: >-
     miniwdl run -d test-output/. --task librarian tools/librarian.wdl read_one_fastq="tests/tools/input/test_R1.fq.gz"
   files:
-    - path: test-output/out/report/test_R1.librarian.tar.gz
+    - path: test-output/out/report/test.librarian.tar.gz
     - path: test-output/out/raw_data/librarian_heatmap.txt

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -23,7 +23,7 @@ task librarian {
     )
 
     command <<<
-        /app/librarian --local -o ~{prefix} ~{read_one_fastq} ~{read_two_fastq}
+        RUST_BACKTRACE=1 /app/librarian --local -o ~{prefix} ~{read_one_fastq} ~{read_two_fastq}
     >>>
 
     # output {

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -30,6 +30,7 @@ task librarian {
 
     output {
         File report = "~{prefix}.tar.gz"
+        File raw_data = "~{prefix}/librarian_heatmap.txt"
     }
 
     runtime {

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -23,7 +23,7 @@ task librarian {
     )
 
     command <<<
-        RUST_BACKTRACE=1 /app/librarian --local -o ~{prefix} ~{read_one_fastq} ~{read_two_fastq}
+        RUST_LOG=trace /app/librarian --local -o ~{prefix} ~{read_one_fastq} ~{read_two_fastq}
     >>>
 
     # output {

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -23,7 +23,7 @@ task librarian {
     )
 
     command <<<
-        RUST_LOG=trace /app/librarian --local -o ~{prefix} ~{read_one_fastq} ~{read_two_fastq}
+        RUST_BACKTRACE=full /app/librarian --local -o ~{prefix} ~{read_one_fastq} ~{read_two_fastq}
     >>>
 
     # output {

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -34,7 +34,7 @@ task librarian {
     runtime {
         memory: "4 GB"
         disk: "~{disk_size_gb} GB"
-        docker: 'docker://ghcr.io/desmondwillowbrook/librarian:1.2'
+        docker: 'ghcr.io/desmondwillowbrook/librarian:1.2'
         maxRetries: max_retries
     }
 }

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -1,0 +1,37 @@
+## # librarian
+
+task librarian {
+    input {
+        File read_one_fastq
+        File read_two_fastq
+        String prefix = sub(
+            basename(read_one_fastq),
+            "([_\.][rR][12])?(\.subsampled)?\.(fastq|fq)(\.gz)?$",
+            ""
+        )
+        Int memory_gb = 4
+        Int modify_disk_size_gb = 0
+        Int max_retries = 1
+    }
+
+    Float read1_size = size(read_one_fastq, "GiB")
+    Float read2_size = size(read_two_fastq, "GiB")
+    Int disk_size_gb = (
+        ceil(read1_size + read2_size) + 10 + modify_disk_size_gb
+    )
+
+    command <<<
+        librarian --local -o ~{prefix} ~{read_one_fastq} ~{read_two_fastq}
+    >>>
+
+    # output {
+    #     File report = 
+    # }
+ 
+    runtime {
+        memory: "~{memory_gb} GB"
+        disk: "~{disk_size_gb} GB"
+        docker: 'ghcr.io/desmondwillowbrook/librarian:latest'
+        maxRetries: max_retries
+    }
+}

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -1,5 +1,7 @@
 ## # librarian
 
+version 1.1
+
 task librarian {
     input {
         File read_one_fastq
@@ -9,7 +11,7 @@ task librarian {
             "([_\.][rR][12])?(\.subsampled)?\.(fastq|fq)(\.gz)?$",
             ""
         )
-        # Int memory_gb = 4
+        Int memory_gb = 4
         Int modify_disk_size_gb = 0
         Int max_retries = 1
     }
@@ -29,7 +31,7 @@ task librarian {
     # }
 
     runtime {
-        memory: "4 GB"
+        memory: "~{memory_gb} GB"
         disk: "~{disk_size_gb} GB"
         docker: 'ghcr.io/desmondwillowbrook/librarian:latest'
         maxRetries: max_retries

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -34,7 +34,7 @@ task librarian {
     runtime {
         memory: "4 GB"
         disk: "~{disk_size_gb} GB"
-        docker: 'ghcr.io/desmondwillowbrook/librarian:latest'
+        docker: 'ghcr.io/desmondwillowbrook/librarian:1.2'
         maxRetries: max_retries
     }
 }

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -7,8 +7,8 @@ task librarian {
         description: "Runs the Librarian tool to derive the likely Illumina library preparation protocol used to generate a read one FASTQ file."
         help: "This version of Librarian has been trained on \"read one\" data of Paired-End sequencing data. It is not intended for use with Single-End data, even though it only accepts a single FASTQ."
         output: {
-            File report = "A tar archive containing the Librarian report and raw data."
-            File raw_data = "The raw data that can be passed to MultiQC."
+            report: "A tar archive containing the Librarian report and raw data."
+            raw_data: "The raw data that can be processed by MultiQC."
         }
     }
 

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -27,7 +27,7 @@ task librarian {
     # output {
     #     File report = 
     # }
- 
+
     runtime {
         memory: "~{memory_gb} GB"
         disk: "~{disk_size_gb} GB"

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -4,10 +4,10 @@ version 1.1
 
 task librarian {
     meta {
-        description: "Runs the Librarian tool to derive the likely Illumina library preparation protocol used to generate a read one FASTQ file."
-        help: "This version of Librarian has been trained on \"read one\" data of Paired-End sequencing data. It is not intended for use with Single-End data, even though it only accepts a single FASTQ."
+        description: "Runs the `librarian` tool to derive the likely Illumina library preparation protocol used to generate a pair of FASTQ files."
+        help: "**WARNING** this tool is not guaranteed to work on all data, and may produce nonsensical results. `librarian` was trained on a limited set of GEO read data (Gene Expression Oriented). This means the input data should be Paired-End, of mouse or human origin, read length should be >50bp, and derived from a library prep kit that is in the `librarian` database. This version of `librarian` has been trained on \"read one\" data of Paired-End sequencing data. It is not intended for use with Single-End data, even though it only accepts a single FASTQ."
         output: {
-            report: "A tar archive containing the Librarian report and raw data."
+            report: "A tar archive containing the `librarian` report and raw data."
             raw_data: "The raw data that can be processed by MultiQC."
         }
     }

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -24,11 +24,13 @@ task librarian {
 
         mkdir ~{prefix}
         RUST_LOG=trace /app/librarian --local --raw -o ~{prefix} ~{read_one_fastq}
+
+        tar -czf ~{prefix}.tar.gz ~{prefix}
     >>>
 
-    # output {
-    #     File report =
-    # }
+    output {
+        File report = "~{prefix}.tar.gz"
+    }
 
     runtime {
         memory: "4 GB"

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -9,7 +9,7 @@ task librarian {
             "([_\.][rR][12])?(\.subsampled)?\.(fastq|fq)(\.gz)?$",
             ""
         )
-        # Int memory_gb = 4
+        Int memory_gb = 4
         Int modify_disk_size_gb = 0
         Int max_retries = 1
     }
@@ -29,7 +29,7 @@ task librarian {
     # }
 
     runtime {
-        memory: "4 GB"
+        memory: "~{memory_gb} GB"
         disk: "~{disk_size_gb} GB"
         docker: 'ghcr.io/desmondwillowbrook/librarian:latest'
         maxRetries: max_retries

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -7,7 +7,7 @@ task librarian {
         File read_one_fastq
         String prefix = sub(
             basename(read_one_fastq),
-            "([_\.][rR][12])?(\.subsampled)?\.(fastq|fq)(\.gz)?$",
+            "([_\\.][rR][12])?(\\.subsampled)?\\.(fastq|fq)(\\.gz)?$",
             ""
         )
         Int modify_disk_size_gb = 0
@@ -24,7 +24,7 @@ task librarian {
 
         mkdir tmp
         export TMPDIR=$(pwd)/tmp
-        RUST_LOG=trace /app/librarian --local -o ~{prefix} ~{read_one_fastq}
+        RUST_LOG=trace /app/librarian --local --raw -o ~{prefix} ~{read_one_fastq}
     >>>
 
     # output {
@@ -34,7 +34,7 @@ task librarian {
     runtime {
         memory: "4 GB"
         disk: "~{disk_size_gb} GB"
-        docker: 'ghcr.io/desmondwillowbrook/librarian:1.2'
+        docker: 'docker://ghcr.io/desmondwillowbrook/librarian:1.2'
         maxRetries: max_retries
     }
 }

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -23,7 +23,7 @@ task librarian {
         set -euo pipefail
 
         mkdir ~{prefix}
-        RUST_LOG=trace /app/librarian --local -o ~{prefix} ~{read_one_fastq}
+        RUST_LOG=trace /app/librarian --local --raw -o ~{prefix} ~{read_one_fastq}
     >>>
 
     # output {

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -21,7 +21,7 @@ task librarian {
     )
 
     command <<<
-        librarian --local -o ~{prefix} ~{read_one_fastq} ~{read_two_fastq}
+        /app/librarian --local -o ~{prefix} ~{read_one_fastq} ~{read_two_fastq}
     >>>
 
     # output {

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -3,15 +3,28 @@
 version 1.1
 
 task librarian {
+    meta {
+        description: "Runs the Librarian tool to derive the likely Illumina library preparation protocol used to generate a read one FASTQ file."
+        help: "This version of Librarian has been trained on \"read one\" data of Paired-End sequencing data. It is not intended for use with Single-End data, even though it only accepts a single FASTQ."
+        output: {
+            File report = "A tar archive containing the Librarian report and raw data."
+            File raw_data = "The raw data that can be passed to MultiQC."
+        }
+    }
+
+    parameter_meta {
+        read_one_fastq: "Read one FASTQ of a Paired-End sample to analyze. May be uncompressed or gzipped."
+        prefix: "Name of the output tar archive. The extension `.tar.gz` will be added."
+        modify_disk_size_gb: "Add to or subtract from dynamic disk space allocation. Default disk size is determined by the size of the inputs. Specified in GB."
+    }
     input {
         File read_one_fastq
         String prefix = sub(
             basename(read_one_fastq),
             "([_\\.][rR][12])?(\\.subsampled)?\\.(fastq|fq)(\\.gz)?$",
             ""
-        )
+        ) + ".librarian"
         Int modify_disk_size_gb = 0
-        Int max_retries = 1
     }
 
     Float read1_size = size(read_one_fastq, "GiB")
@@ -37,6 +50,6 @@ task librarian {
         memory: "4 GB"
         disk: "~{disk_size_gb} GB"
         docker: 'ghcr.io/desmondwillowbrook/librarian:1.2'
-        maxRetries: max_retries
+        maxRetries: 1
     }
 }

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -48,7 +48,7 @@ task librarian {
 
     runtime {
         memory: "4 GB"
-        disk: "~{disk_size_gb} GB"
+        disks: "~{disk_size_gb} GB"
         docker: 'ghcr.io/desmondwillowbrook/librarian:1.2'
         maxRetries: 1
     }

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -36,7 +36,7 @@ task librarian {
         set -euo pipefail
 
         mkdir ~{prefix}
-        RUST_LOG=trace /app/librarian --local --raw -o ~{prefix} ~{read_one_fastq}
+        /app/librarian --local --raw -o ~{prefix} ~{read_one_fastq}
 
         tar -czf ~{prefix}.tar.gz ~{prefix}
     >>>

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -22,8 +22,8 @@ task librarian {
     command <<<
         set -euo pipefail
 
-        mkdir tmp
-        TMPDIR=$(pwd)/tmp RUST_LOG=trace /app/librarian --local -o ~{prefix} ~{read_one_fastq}
+        mkdir ~{prefix}
+        RUST_LOG=trace /app/librarian --local -o ~{prefix} ~{read_one_fastq}
     >>>
 
     # output {

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -9,7 +9,7 @@ task librarian {
             "([_\.][rR][12])?(\.subsampled)?\.(fastq|fq)(\.gz)?$",
             ""
         )
-        Int memory_gb = 4
+        # Int memory_gb = 4
         Int modify_disk_size_gb = 0
         Int max_retries = 1
     }
@@ -29,7 +29,7 @@ task librarian {
     # }
 
     runtime {
-        memory: "~{memory_gb} GB"
+        memory: "4 GB"
         disk: "~{disk_size_gb} GB"
         docker: 'ghcr.io/desmondwillowbrook/librarian:latest'
         maxRetries: max_retries

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -23,8 +23,7 @@ task librarian {
         set -euo pipefail
 
         mkdir tmp
-        export TMPDIR=$(pwd)/tmp
-        RUST_LOG=trace /app/librarian --local --raw -o ~{prefix} ~{read_one_fastq}
+        TMPDIR=$(pwd)/tmp RUST_LOG=trace /app/librarian --local --raw -o ~{prefix} ~{read_one_fastq}
     >>>
 
     # output {

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -23,7 +23,7 @@ task librarian {
     )
 
     command <<<
-        RUST_BACKTRACE=full /app/librarian --local -o ~{prefix} ~{read_one_fastq} ~{read_two_fastq}
+        RUST_LOG=trace /app/librarian --local -o ~{prefix} ~{read_one_fastq} ~{read_two_fastq}
     >>>
 
     # output {

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -5,7 +5,6 @@ version 1.1
 task librarian {
     input {
         File read_one_fastq
-        File read_two_fastq
         String prefix = sub(
             basename(read_one_fastq),
             "([_\.][rR][12])?(\.subsampled)?\.(fastq|fq)(\.gz)?$",
@@ -23,11 +22,15 @@ task librarian {
     )
 
     command <<<
-        RUST_LOG=trace /app/librarian --local -o ~{prefix} ~{read_one_fastq} ~{read_two_fastq}
+        set -euo pipefail
+
+        mkdir tmp
+        export TMPDIR=$(pwd)/tmp
+        RUST_LOG=trace librarian --local -o ~{prefix} ~{read_one_fastq}
     >>>
 
     # output {
-    #     File report = 
+    #     File report =
     # }
 
     runtime {

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -23,7 +23,7 @@ task librarian {
         set -euo pipefail
 
         mkdir tmp
-        TMPDIR=$(pwd)/tmp RUST_LOG=trace /app/librarian --local --raw -o ~{prefix} ~{read_one_fastq}
+        TMPDIR=$(pwd)/tmp RUST_LOG=trace /app/librarian --local -o ~{prefix} ~{read_one_fastq}
     >>>
 
     # output {

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -10,7 +10,6 @@ task librarian {
             "([_\.][rR][12])?(\.subsampled)?\.(fastq|fq)(\.gz)?$",
             ""
         )
-        Int memory_gb = 4
         Int modify_disk_size_gb = 0
         Int max_retries = 1
     }
@@ -33,7 +32,7 @@ task librarian {
     # }
 
     runtime {
-        memory: "~{memory_gb} GB"
+        memory: "4 GB"
         disk: "~{disk_size_gb} GB"
         docker: 'ghcr.io/desmondwillowbrook/librarian:latest'
         maxRetries: max_retries

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -16,9 +16,8 @@ task librarian {
     }
 
     Float read1_size = size(read_one_fastq, "GiB")
-    Float read2_size = size(read_two_fastq, "GiB")
     Int disk_size_gb = (
-        ceil(read1_size + read2_size) + 10 + modify_disk_size_gb
+        ceil(read1_size) + 10 + modify_disk_size_gb
     )
 
     command <<<

--- a/tools/librarian.wdl
+++ b/tools/librarian.wdl
@@ -24,7 +24,7 @@ task librarian {
 
         mkdir tmp
         export TMPDIR=$(pwd)/tmp
-        RUST_LOG=trace librarian --local -o ~{prefix} ~{read_one_fastq}
+        RUST_LOG=trace /app/librarian --local -o ~{prefix} ~{read_one_fastq}
     >>>
 
     # output {

--- a/tools/multiqc.wdl
+++ b/tools/multiqc.wdl
@@ -27,7 +27,7 @@ task multiqc {
     }
 
     Float input_size = size(input_files, "GiB")
-    Int disk_size_gb = ceil(input_size) + 5 + modify_disk_size_gb
+    Int disk_size_gb = ceil(input_size) + 10 + modify_disk_size_gb
 
     String out_tar_gz = prefix + ".tar.gz"
 

--- a/workflows/qc/inputs/multiqc_config_hg38.yaml
+++ b/workflows/qc/inputs/multiqc_config_hg38.yaml
@@ -16,6 +16,7 @@ extra_fn_clean_exts:
   - '.MarkDuplicates'
   - '.collated'
   - '.qualimap_rnaseq_results'
+  - '.librarian'
   - type: remove
     pattern: 'sample_'
 log_filesize_limit: 1000000000

--- a/workflows/qc/inputs/multiqc_config_hg38.yaml
+++ b/workflows/qc/inputs/multiqc_config_hg38.yaml
@@ -7,6 +7,7 @@ run_modules:
   - samtools
   - kraken
   - fastqc
+  - librarian
 extra_fn_clean_exts:
   - '.ValidateSamFile'
   - '.whole_genome'
@@ -15,6 +16,8 @@ extra_fn_clean_exts:
   - '.MarkDuplicates'
   - '.collated'
   - '.qualimap_rnaseq_results'
+  - type: remove
+    pattern: 'sample_'
 log_filesize_limit: 1000000000
 fastqc_config:
   fastqc_theoretical_gc: "hg38_genome"

--- a/workflows/qc/quality-check-standard.wdl
+++ b/workflows/qc/quality-check-standard.wdl
@@ -413,7 +413,7 @@ task parse_input {
 
     parameter_meta {
         coverage_labels: "An array of equal length to `coverage_beds_len` which determines the prefix label applied to coverage output files. If an empty array is supplied, defaults of `regions1`, `regions2`, etc. will be used."
-        rna: "Is the input molecule rna?"
+        rna: "Is the input molecule RNA?"
         gtf_provided: "Was a GTF supplied by the user? Must be `true` if `rna == true`."
         coverage_beds_len: "Length of the provided `coverage_beds` array"
     }

--- a/workflows/qc/quality-check-standard.wdl
+++ b/workflows/qc/quality-check-standard.wdl
@@ -67,6 +67,7 @@ workflow quality_check {
             qualimap_rnaseq_results: "Gzipped tar archive of all QualiMap output files",
             junction_summary: "TSV file containing the `ngsderive junction-annotation` summary",
             junctions: "TSV file containing a detailed list of annotated junctions",
+            librarian_report: "A tar archive containing the `librarian` report and raw data.",
             IntermediateFiles: "Any and all files produced as intermediate during pipeline processing. Only output if `output_intermediate_files = true`."
         }
         allowNestedInputs: true

--- a/workflows/qc/quality-check-standard.wdl
+++ b/workflows/qc/quality-check-standard.wdl
@@ -83,7 +83,7 @@ workflow quality_check {
         coverage_beds: "An array of 3 column BEDs which are passed to the `-b` flag of mosdepth, in order to restrict coverage analysis to select regions"
         coverage_labels: "An array of equal length to `coverage_beds` which determines the prefix label applied to the output files. If omitted, defaults of `regions1`, `regions2`, etc. will be used."
         prefix: "Prefix for all results files"
-        rna: "Is the input molecule RNA? Enabling this option adds RNA-Seq specific analyses to the workflow. If `true`, a GTF file must be provided. If `false`, the GTF file is ignored."
+        rna: "Is the sequenced molecule RNA? Enabling this option adds RNA-Seq specific analyses to the workflow. If `true`, a GTF file must be provided. If `false`, the GTF file is ignored."
         mark_duplicates: "Mark duplicates before analyses? Default behavior is to set this to the value of the `rna` parameter. This is because DNA files are often duplicate marked already, and RNA-Seq files are usually _not_ duplicate marked. Note that regardless of this setting, `picard MarkDuplicates` will be run in order to generate a `*.MarkDuplicates.metrics.txt` file. However if `mark_duplicates` is set to `false`, no BAM will be generated. If set to `true`, a BAM will be generated and passed to selected downstream analyses. **WARNING, this duplicate marked BAM is _not_ ouput by default.** If you would like to output this file, set `output_intermediate_files = true`."
         run_librarian: {
             description: "Run the `librarian` tool to generate a report of the likely Illumina library prep kit used to generate the data. **WARNING** this tool is not guaranteed to work on all data, and may produce nonsensical results. `librarian` was trained on a limited set of GEO read data (Gene Expression Oriented). This means the input data should be Paired-End, of mouse or human origin, read length should be >50bp, and derived from a library prep kit that is in the `librarian` database. By default, this tool is run when `rna == true`.",
@@ -416,7 +416,7 @@ task parse_input {
 
     parameter_meta {
         coverage_labels: "An array of equal length to `coverage_beds_len` which determines the prefix label applied to coverage output files. If an empty array is supplied, defaults of `regions1`, `regions2`, etc. will be used."
-        rna: "Is the input molecule RNA?"
+        rna: "Is the sequenced molecule RNA?"
         gtf_provided: "Was a GTF supplied by the user? Must be `true` if `rna == true`."
         coverage_beds_len: "Length of the provided `coverage_beds` array"
     }

--- a/workflows/qc/quality-check-standard.wdl
+++ b/workflows/qc/quality-check-standard.wdl
@@ -244,7 +244,7 @@ workflow quality_check {
             prefix=post_subsample_prefix + "." + coverage_pair.right,
         }
     }
-    
+
     if (rna) {
         call ngsderive.junction_annotation after quickcheck { input:
             bam=post_subsample_bam,

--- a/workflows/qc/quality-check-standard.wdl
+++ b/workflows/qc/quality-check-standard.wdl
@@ -463,7 +463,7 @@ task parse_input {
     runtime {
         memory: "4 GB"
         disk: "10 GB"
-        container: 'docker://ghcr.io/stjudecloud/util:1.3.0'
+        container: 'ghcr.io/stjudecloud/util:1.3.0'
         maxRetries: 1
     }
 }

--- a/workflows/qc/quality-check-standard.wdl
+++ b/workflows/qc/quality-check-standard.wdl
@@ -343,7 +343,6 @@ workflow quality_check {
             "read_one_fastq_gz": collate_to_fastq.read_one_fastq_gz,
             "read_two_fastq_gz": collate_to_fastq.read_two_fastq_gz,
             "singleton_reads_fastq_gz": collate_to_fastq.singleton_reads_fastq_gz,
-            "interleaved_reads_fastq_gz": collate_to_fastq.interleaved_reads_fastq_gz,
             "duplicate_marked_bam": markdups.duplicate_marked_bam,
             "duplicate_marked_bam_index": markdups.duplicate_marked_bam_index,
             "duplicate_marked_bam_md5": markdups.duplicate_marked_bam_md5
@@ -380,6 +379,7 @@ workflow quality_check {
             = quality_score_distribution.quality_score_distribution_pdf
         File phred_scores = global_phred_scores.phred_scores
         File kraken_report = kraken.report
+        File librarian_report = librarian.report
         File mosdepth_global_dist = wg_coverage.global_dist
         File mosdepth_global_summary = wg_coverage.summary
         Array[File] mosdepth_region_dist = select_all(regions_coverage.region_dist)
@@ -476,7 +476,6 @@ struct IntermediateFiles {
     File? read_one_fastq_gz
     File? read_two_fastq_gz
     File? singleton_reads_fastq_gz
-    File? interleaved_reads_fastq_gz  # TODO this will always be empty? Verify and delete
     File? duplicate_marked_bam
     File? duplicate_marked_bam_index
     File? duplicate_marked_bam_md5

--- a/workflows/qc/quality-check-standard.wdl
+++ b/workflows/qc/quality-check-standard.wdl
@@ -226,8 +226,8 @@ workflow quality_check {
         use_all_cores=use_all_cores,
     }
     if (run_librarian) {
-        call libraran_tasks.librarian { input:
-            read_one_fastq = fqlint.validated_read1,
+        call libraran_tasks.librarian after fqlint { input:
+            read_one_fastq = select_first([collate_to_fastq.read_one_fastq_gz, "undefined"]),
         }
     }
 

--- a/workflows/qc/quality-check-standard.wdl
+++ b/workflows/qc/quality-check-standard.wdl
@@ -76,21 +76,19 @@ workflow quality_check {
         bam: "Input BAM format file to quality check"
         bam_index: "BAM index file corresponding to the input BAM"
         kraken_db: "Kraken2 database. Can be generated with `make-qc-reference.wdl`. Must be a tarball without a root directory."
-        molecule: {
-            description: "Data type",
-            choices: [
-                'DNA',
-                'RNA'
-            ]
-        }
         gtf: "GTF features file. Gzipped or uncompressed. **Required** for RNA-Seq data."
         multiqc_config: "YAML file for configuring MultiQC"
         extra_multiqc_inputs: "An array of additional files to pass directly into MultiQC"
         coverage_beds: "An array of 3 column BEDs which are passed to the `-b` flag of mosdepth, in order to restrict coverage analysis to select regions"
         coverage_labels: "An array of equal length to `coverage_beds` which determines the prefix label applied to the output files. If omitted, defaults of `regions1`, `regions2`, etc. will be used."
         prefix: "Prefix for all results files"
-        mark_duplicates: "Mark duplicates before analyses? Note that regardless of this setting, `picard MarkDuplicates` will be run in order to generate a `*.MarkDuplicates.metrics.txt` file. However if `mark_duplicates` is set to `false`, no BAM will be generated. If set to `true`, a BAM will be generated and passed to selected downstream analyses."
-        output_intermediate_files: "Output intermediate files? FASTQs, if RNA a collated BAM, if `mark_duplicates==true` a duplicate marked BAM with an index and MD5. *WARNING* these files can be large."
+        rna: "Is the input molecule RNA? Enabling this option adds RNA-Seq specific analyses to the workflow. If `true`, a GTF file must be provided. If `false`, the GTF file is ignored."
+        mark_duplicates: "Mark duplicates before analyses? Default behavior is to set this to the value of the `rna` parameter. This is because DNA files are often duplicate marked already, and RNA-Seq files are usually _not_ duplicate marked. Note that regardless of this setting, `picard MarkDuplicates` will be run in order to generate a `*.MarkDuplicates.metrics.txt` file. However if `mark_duplicates` is set to `false`, no BAM will be generated. If set to `true`, a BAM will be generated and passed to selected downstream analyses. **WARNING, this duplicate marked BAM is _not_ ouput by default.** If you would like to output this file, set `output_intermediate_files = true`."
+        run_librarian: {
+            description: "Run the `librarian` tool to generate a report of the likely Illumina library prep kit used to generate the data. **WARNING** this tool is not guaranteed to work on all data, and may produce nonsensical results. `librarian` was trained on a limited set of GEO read data (Gene Expression Oriented). This means the input data should be Paired-End, of mouse or human origin, read length should be >50bp, and derived from a library prep kit that is in the `librarian` database. By default, this tool is run when `rna == true`.",
+            external_help: "https://f1000research.com/articles/11-1122/v2",
+        }
+        output_intermediate_files: "Output intermediate files? FASTQs, if `rna == true` a collated BAM, if `mark_duplicates == true` a duplicate marked BAM, various accessory files like indexes and md5sums. **WARNING** these files can be large."
         use_all_cores: "Use all cores? Recommended for cloud environments."
         subsample_n_reads: "Only process a random sampling of `n` reads. Any `n`<=`0` for processing entire input. Subsampling is done probabalistically so the exact number of reads in the output will have some variation."
     }
@@ -99,14 +97,15 @@ workflow quality_check {
         File bam
         File bam_index
         File kraken_db
-        String molecule
         File? gtf
         File multiqc_config = "https://raw.githubusercontent.com/stjudecloud/workflows/main/workflows/qc/inputs/multiqc_config_hg38.yaml"
         Array[File] extra_multiqc_inputs = []
         Array[File] coverage_beds = []
         Array[String] coverage_labels = []
         String prefix = basename(bam, ".bam")
-        Boolean mark_duplicates = molecule == "RNA"
+        Boolean rna = false
+        Boolean mark_duplicates = rna
+        Boolean run_librarian = rna
         Boolean output_intermediate_files = false
         Boolean use_all_cores = false
         Int subsample_n_reads = -1
@@ -114,7 +113,7 @@ workflow quality_check {
 
     call parse_input { input:
         gtf_provided=defined(gtf),
-        input_molecule=molecule,
+        rna,
         coverage_beds_len=length(coverage_beds),
         coverage_labels=coverage_labels,
     }
@@ -202,11 +201,11 @@ workflow quality_check {
         prefix=post_subsample_prefix,
         # RNA needs a collated BAM for Qualimap
         # DNA can skip the associated storage costs
-        store_collated_bam=(molecule == "RNA"),
+        store_collated_bam = rna,
         # disabling fast_mode enables writing of secondary and supplementary alignments
         # to the collated BAM when processing RNA.
         # Those alignments are used downstream by Qualimap.
-        fast_mode=(molecule != "RNA"),
+        fast_mode = (!rna),
         paired_end=true,  # matches default but prevents user from overriding
         interleaved=false,  # matches default but prevents user from overriding
         use_all_cores=use_all_cores,
@@ -223,8 +222,10 @@ workflow quality_check {
         prefix=post_subsample_prefix,
         use_all_cores=use_all_cores,
     }
-    call libraran_tasks.librarian { input:
-        read_one_fastq = fqlint.validated_read1,
+    if (run_librarian) {
+        call libraran_tasks.librarian { input:
+            read_one_fastq = fqlint.validated_read1,
+        }
     }
 
     call mosdepth.coverage as wg_coverage { input:
@@ -241,7 +242,7 @@ workflow quality_check {
         }
     }
 
-    if (molecule == "RNA") {
+    if (rna) {
         call ngsderive.junction_annotation { input:
             bam=post_subsample_bam,
             bam_index=post_subsample_bam_index,
@@ -283,7 +284,7 @@ workflow quality_check {
             prefix=post_subsample_prefix + ".MarkDuplicates",
         }
     }
-    if (! mark_duplicates) {
+    if (!mark_duplicates) {
         # These analyses are called in the markdups_post workflow.
         # They should still be run if duplicates were not marked.
         call picard.collect_insert_size_metrics { input:
@@ -379,7 +380,6 @@ workflow quality_check {
             = quality_score_distribution.quality_score_distribution_pdf
         File phred_scores = global_phred_scores.phred_scores
         File kraken_report = kraken.report
-        File librarian_report = librarian.report
         File mosdepth_global_dist = wg_coverage.global_dist
         File mosdepth_global_summary = wg_coverage.summary
         Array[File] mosdepth_region_dist = select_all(regions_coverage.region_dist)
@@ -397,6 +397,7 @@ workflow quality_check {
         File? qualimap_rnaseq_results = qualimap_rnaseq.results
         File? junction_summary = junction_annotation.junction_summary
         File? junctions = junction_annotation.junctions
+        File? librarian_report = librarian.report
         IntermediateFiles? intermediate_files = optional_files
     }
 }
@@ -405,21 +406,21 @@ task parse_input {
     meta {
         description: "Parses and validates the `quality_check` workflow's provided inputs"
         outputs: {
-            check: "Dummy output to indicate success and to enable call-caching",
+            check: "Dummy output to indicate success and to enable call-caching",  # TODO: is this still needed with labels?
             labels: "An array of labels to use on the result coverage files associated with each coverage BED"
         }
     }
 
     parameter_meta {
         coverage_labels: "An array of equal length to `coverage_beds_len` which determines the prefix label applied to coverage output files. If an empty array is supplied, defaults of `regions1`, `regions2`, etc. will be used."
-        input_molecule: "Must be `DNA` or `RNA`"
-        gtf_provided: "Was a GTF supplied by the user? Must be `true` if `input_molecule = RNA`."
+        rna: "Is the input molecule rna?"
+        gtf_provided: "Was a GTF supplied by the user? Must be `true` if `rna == true`."
         coverage_beds_len: "Length of the provided `coverage_beds` array"
     }
 
     input {
         Array[String] coverage_labels
-        String input_molecule
+        Boolean rna
         Boolean gtf_provided
         Int coverage_beds_len
     }
@@ -429,13 +430,8 @@ task parse_input {
     command <<<
         EXITCODE=0
 
-        if [ "~{input_molecule}" != "DNA" ] && [ "~{input_molecule}" != "RNA" ]; then
-            >&2 echo "molecule input must be 'DNA' or 'RNA'"
-            EXITCODE=1
-        fi
-
-        if [ "~{input_molecule}" = "RNA" ] && ! ~{gtf_provided}; then
-            >&2 echo "Must supply a GTF if molecule = 'RNA'"
+        if ~{rna} && ! ~{gtf_provided}; then
+            >&2 echo "Must supply a GTF if 'rna == true'"
             EXITCODE=1
         fi
 

--- a/workflows/qc/quality-check-standard.wdl
+++ b/workflows/qc/quality-check-standard.wdl
@@ -5,6 +5,7 @@ version 1.1
 import "../../tools/fastqc.wdl" as fastqc_tasks
 import "../../tools/fq.wdl"
 import "../../tools/kraken2.wdl"
+import "../../tools/librarian.wdl" as libraran_tasks
 import "../../tools/md5sum.wdl"
 import "../../tools/mosdepth.wdl"
 import "../../tools/multiqc.wdl" as multiqc_tasks
@@ -222,6 +223,9 @@ workflow quality_check {
         prefix=post_subsample_prefix,
         use_all_cores=use_all_cores,
     }
+    call libraran_tasks.librarian { input:
+        read_one_fastq = fqlint.validated_read1,
+    }
 
     call mosdepth.coverage as wg_coverage { input:
         bam=post_subsample_bam,
@@ -309,6 +313,7 @@ workflow quality_check {
                 markdups_post.insert_size_metrics,
                 quality_score_distribution.quality_score_distribution_txt,
                 kraken.report,
+                librarian.raw_data,
                 wg_coverage.summary,
                 wg_coverage.global_dist,
                 global_phred_scores.phred_scores,

--- a/workflows/rnaseq/rnaseq-standard-fastq.wdl
+++ b/workflows/rnaseq/rnaseq-standard-fastq.wdl
@@ -237,7 +237,7 @@ task ReadGroup_to_string {
     runtime {
         memory: "4 GB"
         disk: "10 GB"
-        container: 'docker://ghcr.io/stjudecloud/util:1.3.0'
+        container: 'ghcr.io/stjudecloud/util:1.3.0'
         maxRetries: 1
     }
 }

--- a/workflows/rnaseq/rnaseq-standard.wdl
+++ b/workflows/rnaseq/rnaseq-standard.wdl
@@ -181,7 +181,7 @@ task parse_input {
     runtime {
         memory: "4 GB"
         disk: "10 GB"
-        container: 'docker://ghcr.io/stjudecloud/util:1.3.0'
+        container: 'ghcr.io/stjudecloud/util:1.3.0'
         maxRetries: 1
     }
 }

--- a/workflows/scrnaseq/10x-bam-to-fastqs.wdl
+++ b/workflows/scrnaseq/10x-bam-to-fastqs.wdl
@@ -112,7 +112,7 @@ task parse_input {
     runtime {
         memory: "~{memory_gb} GB"
         disk: "~{disk_size_gb} GB"
-        container: 'docker://ghcr.io/stjudecloud/util:1.3.0'
+        container: 'ghcr.io/stjudecloud/util:1.3.0'
         maxRetries: 1
     }
 }


### PR DESCRIPTION
The `librarian` tool is still under development (see https://github.com/DesmondWillowbrook/Librarian/issues/17), but there are passenger-changes I added to this branch I want to see in `main`. So I'm voting for a preemptive merge, and we can update `librarian` later.

The passenger change in question: changing how analyses are toggled on/off in QC. By this, I mean we now present a "base set of analyses" with a number of "extra analyses" that can be **toggled on**, but are **off by default**. This is more-or-less how it currently works, though we had a variety of "toggling methods" and it was awkward IMO.

In practice, the above means dropping the `"DNA"/"RNA"` `String molecule` parameter and replacing it with `Boolean rna = false`. And some tweaking of phrasing in the docs.