### PR TITLE
feat: experimental dnaseq-standard WF

### DIFF
--- a/tools/bwa.wdl
+++ b/tools/bwa.wdl
@@ -208,7 +208,7 @@ task bwa_mem {
         String read_group = ""
         Boolean use_all_cores = false
         Int ncpu = 1
-        Int memory_gb = 5
+        Int memory_gb = 10
         Int modify_disk_size_gb = 0
         Int max_retries = 1
     }

--- a/tools/samtools.wdl
+++ b/tools/samtools.wdl
@@ -86,7 +86,7 @@ task split {
         samtools split \
             --threads "$n_cores" \
             -u ~{prefix}.unaccounted_reads.bam \
-            -f '~{prefix}_%!.bam' \
+            -f '~{prefix}.%!.bam' \
             ~{bam}
         
         samtools head \
@@ -551,7 +551,7 @@ task bam_to_fastq {
 
     parameter_meta {
         bam: "Input name sorted or collated BAM format file to convert into FASTQ(s)"
-        prefix: "Prefix for output FASTQ(s). Extensions `[,_R1,_R2,.singleton].fastq.gz` will be added depending on other options."
+        prefix: "Prefix for output FASTQ(s). Extensions `[,.R1,.R2,.singleton].fastq.gz` will be added depending on other options."
         f: "Only output alignments with all bits set in INT present in the FLAG field. INT can be specified in hex by beginning with `0x` (i.e. /^0x[0-9A-F]+/) or in octal by beginning with `0` (i.e. /^0[0-7]+/)."
         F: "Do not output alignments with any bits set in INT present in the FLAG field. INT can be specified in hex by beginning with `0x` (i.e. /^0x[0-9A-F]+/) or in octal by beginning with `0` (i.e. /^0[0-7]+/). This defaults to 0x900 representing filtering of secondary and supplementary alignments."
         # rf: "Only output alignments with any bits set in INT present in the FLAG field. INT can be specified in hex by beginning with `0x` (i.e. /^0x[0-9A-F]+/), in octal by beginning with `0` (i.e. /^0[0-7]+/)."  # introduced in v1.18 no quay.io image yet
@@ -606,11 +606,11 @@ task bam_to_fastq {
             -G ~{G} \
             -1 ~{if interleaved
                 then prefix + ".fastq.gz"
-                else prefix + "_R1.fastq.gz"
+                else prefix + ".R1.fastq.gz"
             } \
             -2 ~{
                 if paired_end then (
-                    if interleaved then prefix + ".fastq.gz" else prefix + "_R2.fastq.gz"
+                    if interleaved then prefix + ".fastq.gz" else prefix + ".R2.fastq.gz"
                 )
                 else "junk.read2.fastq.gz"
             } \
@@ -634,8 +634,8 @@ task bam_to_fastq {
     output {
         # one of `read_one_fastq_gz` or `interleaved_reads_fastq_gz` is
         # guaranteed to exist at the end of execution
-        File? read_one_fastq_gz = "~{prefix}_R1.fastq.gz"
-        File? read_two_fastq_gz = "~{prefix}_R2.fastq.gz"
+        File? read_one_fastq_gz = "~{prefix}.R1.fastq.gz"
+        File? read_two_fastq_gz = "~{prefix}.R2.fastq.gz"
         File? singleton_reads_fastq_gz = "~{prefix}.singleton.fastq.gz"
         File? interleaved_reads_fastq_gz = "~{prefix}.fastq.gz"
     }
@@ -663,7 +663,7 @@ task collate_to_fastq {
 
     parameter_meta {
         bam: "Input BAM format file to collate and convert to FASTQ(s)"
-        prefix: "Prefix for the collated BAM and FASTQ files. The extensions `.collated.bam` and `[,_R1,_R2,.singleton].fastq.gz` will be added."
+        prefix: "Prefix for the collated BAM and FASTQ files. The extensions `.collated.bam` and `[,.R1,.R2,.singleton].fastq.gz` will be added."
         f: "Only output alignments with all bits set in INT present in the FLAG field. INT can be specified in hex by beginning with `0x` (i.e. /^0x[0-9A-F]+/) or in octal by beginning with `0` (i.e. /^0[0-7]+/)."
         F: "Do not output alignments with any bits set in INT present in the FLAG field. INT can be specified in hex by beginning with `0x` (i.e. /^0x[0-9A-F]+/) or in octal by beginning with `0` (i.e. /^0[0-7]+/). This defaults to 0x900 representing filtering of secondary and supplementary alignments."
         # rf: "Only output alignments with any bits set in INT present in the FLAG field. INT can be specified in hex by beginning with `0x` (i.e. /^0x[0-9A-F]+/), in octal by beginning with `0` (i.e. /^0[0-7]+/)."  # introduced in v1.18 no quay.io image yet
@@ -732,13 +732,13 @@ task collate_to_fastq {
                 -G ~{G} \
                 -1 ~{if interleaved
                     then prefix + ".fastq.gz"
-                    else prefix + "_R1.fastq.gz"
+                    else prefix + ".R1.fastq.gz"
                 } \
                 -2 ~{
                     if paired_end then (
                         if interleaved
                         then prefix + ".fastq.gz"
-                        else prefix + "_R2.fastq.gz"
+                        else prefix + ".R2.fastq.gz"
                     )
                     else "junk.read2.fastq.gz"
                 } \
@@ -762,8 +762,8 @@ task collate_to_fastq {
         # one of `read_one_fastq_gz` or `interleaved_reads_fastq_gz` is
         # guaranteed to exist at the end of execution
         File? collated_bam = "~{prefix}.collated.bam"
-        File? read_one_fastq_gz = "~{prefix}_R1.fastq.gz"
-        File? read_two_fastq_gz = "~{prefix}_R2.fastq.gz"
+        File? read_one_fastq_gz = "~{prefix}.R1.fastq.gz"
+        File? read_two_fastq_gz = "~{prefix}.R2.fastq.gz"
         File? singleton_reads_fastq_gz = "~{prefix}.singleton.fastq.gz"
         File? interleaved_reads_fastq_gz = "~{prefix}.fastq.gz"
     }

--- a/workflows/dnaseq/dnaseq-standard.wdl
+++ b/workflows/dnaseq/dnaseq-standard.wdl
@@ -48,6 +48,7 @@ workflow dnaseq_standard {
             # find tab literals, replace with '\\t' (which must be written as '\\\\t')
             # '\\t' is subbed into command blocks as '\t'
             read_group=sub(tuple.right, "\t", "\\\\t"),
+            use_all_cores=use_all_cores,
             max_retries=max_retries
         }
         call picard.sort { input:

--- a/workflows/dnaseq/dnaseq-standard.wdl
+++ b/workflows/dnaseq/dnaseq-standard.wdl
@@ -58,6 +58,8 @@ workflow dnaseq_standard {
     call samtools.merge { input:
         bams=sort.sorted_bam,
         prefix=prefix,
+        combine_pg=false,
+        use_all_cores=use_all_cores,
         max_retries=max_retries
     }
 }

--- a/workflows/dnaseq/dnaseq-standard.wdl
+++ b/workflows/dnaseq/dnaseq-standard.wdl
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MIT
+# Copyright St. Jude Children's Research Hospital
+version 1.1
+
+import "../../tools/bwa.wdl"
+import "../../tools/picard.wdl"
+import "../../tools/samtools.wdl"
+import "../../tools/util.wdl"
+import "../general/bam-to-fastqs.wdl" as bam_to_fastqs_wf
+
+workflow rnaseq_standard {
+    input {
+        File bam
+        File bwa_db
+        Boolean validate_input = true
+    }
+
+    if (validate_input) {
+        call picard.validate_bam as validate_input_bam { input:
+            bam=bam,
+            max_retries=max_retries
+        }
+    }
+
+    call util.get_read_groups { input:
+        bam=bam,
+        format_for_star=false,
+        max_retries=max_retries
+    }  # TODO what happens if no RG records?
+    call bam_to_fastqs_wf.bam_to_fastqs { input:
+        bam=bam,
+        paired_end=true,  # matches default but prevents user from overriding
+        use_all_cores=use_all_cores,
+        max_retries=max_retries
+    }
+
+    scatter (tuple in zip(
+        zip(bam_to_fastqs.read1s, bam_to_fastqs.read2s),
+        read_groups
+    )) {
+        call bwa.bwa_mem { input:
+            read_one_fastq_gz=tuple.left.left,
+            read_two_fastq_gz=tuple.left.right,
+            bwa_db_tar_gz=bwa_db,
+            read_group=tuple.right,
+            max_retries=max_retries
+        }
+    }
+    call samtools.merge { input: bams=bwa_mem.bam }
+}

--- a/workflows/dnaseq/dnaseq-standard.wdl
+++ b/workflows/dnaseq/dnaseq-standard.wdl
@@ -50,6 +50,14 @@ workflow dnaseq_standard {
             read_group=sub(tuple.right, "\t", "\\\\t"),
             max_retries=max_retries
         }
+        call picard.sort { input:
+            bam=bwa_mem.bam,
+            max_retries=max_retries
+        }
     }
-    call samtools.merge { input: bams=bwa_mem.bam, prefix=prefix }
+    call samtools.merge { input:
+        bams=sort.sorted_bam,
+        prefix=prefix,
+        max_retries=max_retries
+    }
 }

--- a/workflows/dnaseq/dnaseq-standard.wdl
+++ b/workflows/dnaseq/dnaseq-standard.wdl
@@ -14,6 +14,7 @@ workflow rnaseq_standard {
         File bwa_db
         Int? max_retries
         Boolean validate_input = true
+        Boolean use_all_cores = false
     }
 
     if (validate_input) {

--- a/workflows/dnaseq/dnaseq-standard.wdl
+++ b/workflows/dnaseq/dnaseq-standard.wdl
@@ -12,6 +12,7 @@ workflow rnaseq_standard {
     input {
         File bam
         File bwa_db
+        Int? max_retries
         Boolean validate_input = true
     }
 

--- a/workflows/dnaseq/dnaseq-standard.wdl
+++ b/workflows/dnaseq/dnaseq-standard.wdl
@@ -8,11 +8,12 @@ import "../../tools/samtools.wdl"
 import "../../tools/util.wdl"
 import "../general/bam-to-fastqs.wdl" as bam_to_fastqs_wf
 
-workflow rnaseq_standard {
+workflow dnaseq_standard {
     input {
         File bam
         File bwa_db
         Int? max_retries
+        String prefix = basename(bam, ".bam")
         Boolean validate_input = true
         Boolean use_all_cores = false
     }
@@ -44,9 +45,11 @@ workflow rnaseq_standard {
             read_one_fastq_gz=tuple.left.left,
             read_two_fastq_gz=tuple.left.right,
             bwa_db_tar_gz=bwa_db,
-            read_group=sub(tuple.right, "\t", "\\t"),
+            # find tab literals, replace with '\\t'
+            # '\\t' is subbed into command blocks as '\t'
+            read_group=sub(tuple.right, "\t", "\\\\t"),
             max_retries=max_retries
         }
     }
-    call samtools.merge { input: bams=bwa_mem.bam }
+    call samtools.merge { input: bams=bwa_mem.bam, prefix=prefix }
 }

--- a/workflows/dnaseq/dnaseq-standard.wdl
+++ b/workflows/dnaseq/dnaseq-standard.wdl
@@ -45,7 +45,7 @@ workflow dnaseq_standard {
             read_one_fastq_gz=tuple.left.left,
             read_two_fastq_gz=tuple.left.right,
             bwa_db_tar_gz=bwa_db,
-            # find tab literals, replace with '\\t'
+            # find tab literals, replace with '\\t' (which must be written as '\\\\t')
             # '\\t' is subbed into command blocks as '\t'
             read_group=sub(tuple.right, "\t", "\\\\t"),
             max_retries=max_retries

--- a/workflows/dnaseq/dnaseq-standard.wdl
+++ b/workflows/dnaseq/dnaseq-standard.wdl
@@ -36,7 +36,7 @@ workflow rnaseq_standard {
 
     scatter (tuple in zip(
         zip(bam_to_fastqs.read1s, bam_to_fastqs.read2s),
-        read_groups
+        get_read_groups.read_groups
     )) {
         call bwa.bwa_mem { input:
             read_one_fastq_gz=tuple.left.left,

--- a/workflows/dnaseq/dnaseq-standard.wdl
+++ b/workflows/dnaseq/dnaseq-standard.wdl
@@ -1,3 +1,5 @@
+## **WARNING:** this workflow is experimental! Use at your own risk!
+#
 # SPDX-License-Identifier: MIT
 # Copyright St. Jude Children's Research Hospital
 version 1.1
@@ -8,7 +10,7 @@ import "../../tools/samtools.wdl"
 import "../../tools/util.wdl"
 import "../general/bam-to-fastqs.wdl" as bam_to_fastqs_wf
 
-workflow dnaseq_standard {
+workflow dnaseq_standard_experimental {
     input {
         File bam
         File bwa_db

--- a/workflows/dnaseq/dnaseq-standard.wdl
+++ b/workflows/dnaseq/dnaseq-standard.wdl
@@ -44,7 +44,7 @@ workflow rnaseq_standard {
             read_one_fastq_gz=tuple.left.left,
             read_two_fastq_gz=tuple.left.right,
             bwa_db_tar_gz=bwa_db,
-            read_group=tuple.right,
+            read_group=sub(tuple.right, "\t", "\\t"),
             max_retries=max_retries
         }
     }


### PR DESCRIPTION
This PR has a few changes alongside the dnaseq-standard experimental WF.

* fix: `get_read_group` usage in rnaseq-standard
* feat: read2 support in bwa-mem
* style: split FASTQs naming went from `<sample>_<read group>_R<1/2>.fastq` to `<sample>.<read group>.R<1/2>.fastq`