### PR TITLE
fix: make index optional

### DIFF
--- a/tests/tools/test_picard.py
+++ b/tests/tools/test_picard.py
@@ -1,0 +1,7 @@
+import pathlib
+import pytest
+
+@pytest.mark.workflow('picard_sort_queryname')
+def test_picard_sort_queryname(workflow_dir):
+    exists = pathlib.Path(workflow_dir, 'test-output/out/sorted_bam_index/test.bwa_aln_pe.sorted.bam.bai').exists()
+    assert exists is False

--- a/tests/tools/test_picard.yaml
+++ b/tests/tools/test_picard.yaml
@@ -37,6 +37,16 @@
     miniwdl run --verbose -d test-output/. --task sort tools/picard.wdl bam="tests/tools/input/test.bwa_aln_pe.bam" memory_gb=16
   files:
     - path: test-output/out/sorted_bam/test.bwa_aln_pe.sorted.bam
+    - path: test-output/out/sorted_bam_index/test.bwa_aln_pe.sorted.bam.bai
+
+- name: picard_sort_queryname
+  tags:
+    - miniwdl
+    - picard
+  command: >-
+    miniwdl run --verbose -d test-output/. --task sort tools/picard.wdl bam="tests/tools/input/test.bwa_aln_pe.bam" memory_gb=16 sort_order="queryname"
+  files:
+    - path: test-output/out/sorted_bam/test.bwa_aln_pe.sorted.bam
 
 - name: picard_merge_sam_files
   tags:

--- a/tools/picard.wdl
+++ b/tools/picard.wdl
@@ -318,12 +318,14 @@ task sort {
             --CREATE_MD5_FILE true \
             --VALIDATION_STRINGENCY ~{validation_stringency}
 
-        mv ~{prefix}.bai ~{outfile_name}.bai
+        if [ -f "~{prefix}.bai" ]; then
+            mv ~{prefix}.bai ~{outfile_name}.bai
+        fi
     >>>
 
     output {
         File sorted_bam = outfile_name
-        File sorted_bam_index = outfile_name + ".bai"
+        File? sorted_bam_index = outfile_name + ".bai"
         File sorted_bam_md5 = outfile_name + ".md5"
     }
 

--- a/tools/picard.wdl
+++ b/tools/picard.wdl
@@ -318,6 +318,8 @@ task sort {
             --CREATE_MD5_FILE true \
             --VALIDATION_STRINGENCY ~{validation_stringency}
 
+        # CREATE_INDEX true only applies when the sort order
+        # is coordinate. So the index may not exist.
         if [ -f "~{prefix}.bai" ]; then
             mv ~{prefix}.bai ~{outfile_name}.bai
         fi


### PR DESCRIPTION
For non-coordinate sorts, `picard SortSam` does not output a BAM index, even if `CREATE_INDEX` is `true`. This puts an existence check around the rename of the BAI file and also makes the output bam_index an optional output. Fortunately, it appears that we are not using the generated index in any of our pipelines as something always consumes and transforms the BAM downstream, so it ends up reindexed.

Resolves #155 