### PR TITLE
ci: use public Sprocket action

### DIFF
--- a/.github/workflows/sprocket-check.yaml
+++ b/.github/workflows/sprocket-check.yaml
@@ -1,0 +1,13 @@
+name: Workflows Sprocket Check
+
+on: [push]
+
+jobs:
+    sprocket_check:
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v2
+        - name: Run sprocket
+          uses: stjude-rust-labs/sprocket-action@v0.3.0
+          with:
+            exclude-paths: template

--- a/.github/workflows/sprocket-check.yaml
+++ b/.github/workflows/sprocket-check.yaml
@@ -8,6 +8,6 @@ jobs:
         steps:
         - uses: actions/checkout@v2
         - name: Run sprocket
-          uses: stjude-rust-labs/sprocket-action@v0.3.0
+          uses: stjude-rust-labs/sprocket-action@v0.4.0
           with:
             exclude-patterns: template

--- a/.github/workflows/sprocket-check.yaml
+++ b/.github/workflows/sprocket-check.yaml
@@ -10,4 +10,4 @@ jobs:
         - name: Run sprocket
           uses: stjude-rust-labs/sprocket-action@v0.3.0
           with:
-            exclude-paths: template
+            exclude-patterns: template

--- a/.github/workflows/sprocket-lint.yaml
+++ b/.github/workflows/sprocket-lint.yaml
@@ -8,7 +8,7 @@ jobs:
         steps:
         - uses: actions/checkout@v2
         - name: Run sprocket
-          uses: stjude-rust-labs/sprocket-action@v0.3.0
+          uses: stjude-rust-labs/sprocket-action@v0.4.0
           with:
             lint: true
             exclude-patterns: template

--- a/.github/workflows/sprocket-lint.yaml
+++ b/.github/workflows/sprocket-lint.yaml
@@ -11,6 +11,6 @@ jobs:
           uses: stjude-rust-labs/sprocket-action@v0.3.0
           with:
             lint: true
-            exclude-paths: template
+            exclude-patterns: template
             deny-warnings: true
             deny-notes: true

--- a/.github/workflows/sprocket-lint.yaml
+++ b/.github/workflows/sprocket-lint.yaml
@@ -7,21 +7,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v2
-        - name: Set up Rust
-          uses: actions-rust-lang/setup-rust-toolchain@v1
-          with:
-            toolchain: nightly
-        - name: Install sprocket
-          run: |
-            cargo install sprocket
         - name: Run sprocket
-          run: |
-            EXITCODE=0
-            echo "Checking WDL files using \`sprocket lint\`."
-            shopt -s extglob
-            files=$(find ./!(template) -name '*.wdl')
-            for file in $files; do
-              echo "  [***] $file [***]"
-              sprocket lint "$file" || EXITCODE=$(($? || EXITCODE))
-            done
-            exit $EXITCODE
+          uses: stjude-rust-labs/sprocket-action@v0.3.0
+          with:
+            lint: true
+            exclude-paths: template
+            deny-warnings: true
+            deny-notes: true


### PR DESCRIPTION
Switch to the public Sprocket action instead of installing Rust and Sprocket on the runner manually.