### PR TITLE
fix: add token to environment for gh cli, jq query update, digest comparison update

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -77,7 +77,6 @@ jobs:
           docker pull ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.TOOL }}:${{ env.TAG_TO_CHECK }} || true
           remote_digest=$(docker inspect ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.TOOL }}:${{ env.TAG_TO_CHECK }} --format='{{index .RepoDigests 0}}' | cut -d '@' -f 2 || echo -n '')
           local_digest=$(docker inspect ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.TOOL }}:local --format='{{index .RepoDigests 0}}' | cut -d '@' -f 2 || echo -n '')
-          echo $(docker inspect ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.TOOL }}:local)
           if [ "$remote_digest" != "" ] && [ "$remote_digest" != "$local_digest" ]; then
             echo "Digests do not match!"
             echo "Remote: $remote_digest"

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -76,14 +76,14 @@ jobs:
         run: |
           docker pull ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.TOOL }}:${{ env.TAG_TO_CHECK }} || true
           remote_digest=$(docker inspect ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.TOOL }}:${{ env.TAG_TO_CHECK }} --format='{{index .RepoDigests 0}}' | cut -d '@' -f 2 || echo -n '')
-          local_digest=${{ steps.build.outputs.digest }}
+          local_digest=$(docker inspect ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.TOOL }}:local --format='{{index .RepoDigests 0}}' | cut -d '@' -f 2 || echo -n '')
           echo $(docker inspect ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.TOOL }}:local)
           if [ "$remote_digest" != "" ] && [ "$remote_digest" != "$local_digest" ]; then
             echo "Digests do not match!"
             echo "Remote: $remote_digest"
             echo "Local: $local_digest"
             echo "Should you increment the version number?"
-            # exit 1
+            exit 1
           fi
       - name: Run Snyk to check Docker image for vulnerabilities
         # Snyk can be used to break the build when it detects vulnerabilities.

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -77,6 +77,7 @@ jobs:
           docker pull ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.TOOL }}:${{ env.TAG_TO_CHECK }} || true
           remote_digest=$(docker inspect ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.TOOL }}:${{ env.TAG_TO_CHECK }} --format='{{index .RepoDigests 0}}' | cut -d '@' -f 2 || echo -n '')
           local_digest=${{ steps.build.outputs.digest }}
+          echo $(docker inspect ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.TOOL }}:local)
           if [ "$remote_digest" != "" ] && [ "$remote_digest" != "$local_digest" ]; then
             echo "Digests do not match!"
             echo "Remote: $remote_digest"

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -76,7 +76,7 @@ jobs:
         run: |
           docker pull ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.TOOL }}:${{ env.TAG_TO_CHECK }} || true
           remote_digest=$(docker inspect ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.TOOL }}:${{ env.TAG_TO_CHECK }} --format='{{index .RepoDigests 0}}' | cut -d '@' -f 2 || echo -n '')
-          local_digest=$(docker inspect ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.TOOL }}:local --format='{{index .RepoDigests 0}}' | cut -d '@' -f 2 || echo -n '')
+          local_digest=$(docker inspect ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.TOOL }}:local --format='{{index .RepoDigests 0}}' | cut -d '@' -f 2)
           if [ "$remote_digest" != "" ] && [ "$remote_digest" != "$local_digest" ]; then
             echo "Digests do not match!"
             echo "Remote: $remote_digest"

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -82,7 +82,7 @@ jobs:
             echo "Remote: $remote_digest"
             echo "Local: $local_digest"
             echo "Should you increment the version number?"
-            exit 1
+            # exit 1
           fi
       - name: Run Snyk to check Docker image for vulnerabilities
         # Snyk can be used to break the build when it detects vulnerabilities.

--- a/.github/workflows/docker-clean.yaml
+++ b/.github/workflows/docker-clean.yaml
@@ -27,6 +27,7 @@ jobs:
             matrix:
                 image: ${{ fromJson(needs.list-images.outputs.images) }}
         steps:
+          - uses: actions/checkout@v3
           - name: Set Env
             run: |
               echo "TOOL=$(jq -r .name ${{ matrix.image }}/package.json)" >> $GITHUB_ENV

--- a/.github/workflows/docker-clean.yaml
+++ b/.github/workflows/docker-clean.yaml
@@ -35,7 +35,7 @@ jobs:
               echo "GH_REF=${GITHUB_REF##*/}" >> $GITHUB_ENV
           - name: Get versions to delete
             run: | # NOTE: This will delete any images for branch names that contain the current branch name as a prefix.
-               gh api /orgs/${{ github.repository_owner }}/packages/container/${{ env.TOOL }}/versions | jq -r '.[] | select(isempty(.metadata.container.tags[] or (.metadata.container.tags[] | contains(${{ env.GH_REF }}))) | .id' > versions.txt
+               gh api /orgs/${{ github.repository_owner }}/packages/container/${{ env.TOOL }}/versions | jq -r '.[] | select(isempty(.metadata.container.tags[]) or (.metadata.container.tags[] | contains("${{ env.GH_REF }}"))) | .id' > versions.txt
                echo "IDS=$(tr -s '\n' ',' < versions.txt | sed 's/,$//')" >> $GITHUB_ENV
           - uses: actions/delete-package-versions@v5
             with: 

--- a/.github/workflows/docker-clean.yaml
+++ b/.github/workflows/docker-clean.yaml
@@ -36,7 +36,9 @@ jobs:
               echo "GH_REF=${GITHUB_REF##*/}" >> $GITHUB_ENV
           - name: Get versions to delete
             run: | # NOTE: This will delete any images for branch names that contain the current branch name as a prefix.
-               gh api /orgs/${{ github.repository_owner }}/packages/container/${{ env.TOOL }}/versions | jq -r '.[] | select(isempty(.metadata.container.tags[]) or (.metadata.container.tags[] | contains("branch-${{ github.event.ref }}"))) | .id' > versions.txt
+               REF="${{ github.event.ref }}"
+               REF="${REF##*/}"
+               gh api /orgs/${{ github.repository_owner }}/packages/container/${{ env.TOOL }}/versions | jq -r '.[] | select(isempty(.metadata.container.tags[]) or (.metadata.container.tags[] | contains("branch-${REF}"))) | .id' > versions.txt
                echo "IDS=$(tr -s '\n' ',' < versions.txt | sed 's/,$//')" >> $GITHUB_ENV
           - uses: actions/delete-package-versions@v5
             with: 

--- a/.github/workflows/docker-clean.yaml
+++ b/.github/workflows/docker-clean.yaml
@@ -3,6 +3,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  GH_TOKEN: ${{ github.token }}
 
 jobs:
     list-images:

--- a/.github/workflows/docker-clean.yaml
+++ b/.github/workflows/docker-clean.yaml
@@ -36,7 +36,7 @@ jobs:
               echo "GH_REF=${GITHUB_REF##*/}" >> $GITHUB_ENV
           - name: Get versions to delete
             run: | # NOTE: This will delete any images for branch names that contain the current branch name as a prefix.
-               gh api /orgs/${{ github.repository_owner }}/packages/container/${{ env.TOOL }}/versions | jq -r '.[] | select(isempty(.metadata.container.tags[]) or (.metadata.container.tags[] | contains("${{ github.event.ref }}"))) | .id' > versions.txt
+               gh api /orgs/${{ github.repository_owner }}/packages/container/${{ env.TOOL }}/versions | jq -r '.[] | select(isempty(.metadata.container.tags[]) or (.metadata.container.tags[] | contains("branch-${{ github.event.ref }}"))) | .id' > versions.txt
                echo "IDS=$(tr -s '\n' ',' < versions.txt | sed 's/,$//')" >> $GITHUB_ENV
           - uses: actions/delete-package-versions@v5
             with: 

--- a/.github/workflows/docker-clean.yaml
+++ b/.github/workflows/docker-clean.yaml
@@ -36,7 +36,7 @@ jobs:
               echo "GH_REF=${GITHUB_REF##*/}" >> $GITHUB_ENV
           - name: Get versions to delete
             run: | # NOTE: This will delete any images for branch names that contain the current branch name as a prefix.
-               gh api /orgs/${{ github.repository_owner }}/packages/container/${{ env.TOOL }}/versions | jq -r '.[] | select(isempty(.metadata.container.tags[]) or (.metadata.container.tags[] | contains("${{ env.GH_REF }}"))) | .id' > versions.txt
+               gh api /orgs/${{ github.repository_owner }}/packages/container/${{ env.TOOL }}/versions | jq -r '.[] | select(isempty(.metadata.container.tags[]) or (.metadata.container.tags[] | contains("${{ github.event.ref }}"))) | .id' > versions.txt
                echo "IDS=$(tr -s '\n' ',' < versions.txt | sed 's/,$//')" >> $GITHUB_ENV
           - uses: actions/delete-package-versions@v5
             with: 


### PR DESCRIPTION
- The `gh` CLI tool needs to token to be present in the environment to authenticate.
- Updated the digest check for the locally built image for the comparison check.
- Checks out the repo for the delete step since it needs to read the `package.json` files.
- Fixes a bug in the `jq` filtering of docker images.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [ ] The code passes all CI tests without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in any relevant CHANGELOGs (when appropriate).
- [ ] If you have made any changes to the `scripts/` or `docker/` directories, please ensure any image versions have been incremented accordingly!
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).