### PR TITLE
chore: port remaining in-lined scripts to scripts/

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         tag: ${{ fromJson(needs.list-tags.outputs.tags) }}
+      fail-fast: false
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Blacklist common bioinformatics formats used in these workflows.
+# Ignore common bioinformatics formats used in these workflows.
 **/*.fastq.gz
 **/*.fa
 **/*.gtf
@@ -6,7 +6,7 @@
 **/*.sam
 **/*.log
 
-# Blacklist Cromwell and Womtool and miniwdl files
+# Ignore Cromwell and Womtool and miniwdl files
 **/cromwell*
 **/womtool*
 *.jar
@@ -15,15 +15,18 @@ miniwdl_singularity_cache/
 _LAST
 202*/
 
-# Blacklist test directories
+# Ignore test directories
 test-output/
 **/__pycache__
 
-# Blacklist OS generated files
+# Ignore OS generated files
 .DS_Store
 
 # Commonly used folder for putting miniwdl results in during testing
 results/
+
+# Ignore `sprocket doc` dir
+docs/
 
 # ignore any tags files that are generated
 tags

--- a/data_structures/flag_filter.wdl
+++ b/data_structures/flag_filter.wdl
@@ -118,7 +118,7 @@ task validate_string_is_12bit_oct_dec_or_hex {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }

--- a/data_structures/flag_filter.wdl
+++ b/data_structures/flag_filter.wdl
@@ -118,7 +118,7 @@ task validate_string_is_12bit_oct_dec_or_hex {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:2.1.0"
+        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
         maxRetries: 1
     }
 }

--- a/data_structures/flag_filter.wdl
+++ b/data_structures/flag_filter.wdl
@@ -118,7 +118,7 @@ task validate_string_is_12bit_oct_dec_or_hex {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:2.0.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }

--- a/data_structures/read_group.wdl
+++ b/data_structures/read_group.wdl
@@ -104,7 +104,7 @@ task read_group_to_string {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:2.1.0"
+        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
         maxRetries: 1
     }
 }
@@ -441,7 +441,7 @@ task validate_read_group {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:2.1.0"
+        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
         maxRetries: 0
     }
 }

--- a/data_structures/read_group.wdl
+++ b/data_structures/read_group.wdl
@@ -104,7 +104,7 @@ task read_group_to_string {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }
@@ -441,7 +441,7 @@ task validate_read_group {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 0
     }
 }

--- a/data_structures/read_group.wdl
+++ b/data_structures/read_group.wdl
@@ -104,7 +104,7 @@ task read_group_to_string {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:2.0.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }
@@ -441,7 +441,7 @@ task validate_read_group {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:2.0.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 0
     }
 }

--- a/docker/minfi/Dockerfile
+++ b/docker/minfi/Dockerfile
@@ -8,4 +8,4 @@ RUN R --no-save <<SCRIPT
     BiocManager::install("IlluminaHumanMethylationEPICanno.ilm10b4.hg19")
 SCRIPT
 
-COPY --from=scripts --chmod=777 methylation/methylation-preprocess.R /usr/local/bin/methylation-preprocess.R
+COPY --from=scripts --chmod=777 methylation/methylation-preprocess.R /scripts/methylation/methylation-preprocess.R

--- a/docker/minfi/package.json
+++ b/docker/minfi/package.json
@@ -1,5 +1,5 @@
 {
     "name": "minfi",
     "version": "1.48.0",
-    "revision": "2"
+    "revision": "3"
 }

--- a/docker/pandas/Dockerfile
+++ b/docker/pandas/Dockerfile
@@ -1,4 +1,4 @@
 FROM quay.io/biocontainers/pandas:2.2.1
 
-COPY --from=scripts --chmod=777 methylation/combine.py /usr/local/bin/combine.py
-COPY --from=scripts --chmod=777 methylation/filter.py /usr/local/bin/filter.py
+COPY --from=scripts --chmod=777 methylation/combine.py /scripts/methylation/combine.py
+COPY --from=scripts --chmod=777 methylation/filter.py /scripts/methylation/filter.py

--- a/docker/pandas/package.json
+++ b/docker/pandas/package.json
@@ -1,5 +1,5 @@
 {
     "name": "pandas",
     "version": "2.2.1",
-    "revision": "3"
+    "revision": "4"
 }

--- a/docker/python-plotting/Dockerfile
+++ b/docker/python-plotting/Dockerfile
@@ -4,4 +4,4 @@ RUN apk add --no-cache bash
 
 RUN pip install pandas numpy matplotlib seaborn plotly
 
-COPY --from=scripts --chmod=777 methylation/plot_umap.py /usr/local/bin/plot_umap.py
+COPY --from=scripts --chmod=777 methylation/plot_umap.py /scripts/methylation/plot_umap.py

--- a/docker/python-plotting/package.json
+++ b/docker/python-plotting/package.json
@@ -1,4 +1,4 @@
 {
     "name": "python-plotting",
-    "version": "2.0.0"
+    "version": "2.0.1"
 }

--- a/docker/star/Dockerfile
+++ b/docker/star/Dockerfile
@@ -11,6 +11,6 @@ COPY --from=python /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/
 COPY --from=python /usr/lib/python3.7/ /usr/local/lib/python3.7/
 COPY --from=python /usr/bin/python3 /usr/local/bin/
 
-COPY --from=scripts star/sort_star_input.py /home
+COPY --from=scripts star/sort_star_input.py /scripts/star/sort_star_input.py
 
 ENTRYPOINT ["STAR"]

--- a/docker/star/package.json
+++ b/docker/star/package.json
@@ -1,5 +1,5 @@
 {
     "name": "star",
     "version": "2.7.11b",
-    "revision": "5"
+    "revision": "6"
 }

--- a/docker/umap/Dockerfile
+++ b/docker/umap/Dockerfile
@@ -7,4 +7,4 @@ RUN apk add --no-cache build-base llvm15-dev bash \
 
 RUN pip install umap-learn==0.5.7 pandas
 
-COPY --from=scripts --chmod=777 methylation/generate_umap.py /usr/local/bin/generate_umap.py
+COPY --from=scripts --chmod=777 methylation/generate_umap.py /scripts/methylation/generate_umap.py

--- a/docker/umap/package.json
+++ b/docker/umap/package.json
@@ -1,5 +1,5 @@
 {
     "name": "umap",
     "version": "0.5.7",
-    "revision": "4"
+    "revision": "5"
 }

--- a/docker/util/Dockerfile
+++ b/docker/util/Dockerfile
@@ -6,3 +6,5 @@ RUN apt-get update \
       liblzma-dev jq python3 python3-pip parallel \
       python3-csvkit python3-pysam -y \
     && rm -r /var/lib/apt/lists/*
+
+COPY --from=scripts --chmod=777 util/calc_global_phred_scores.py /scripts/util/calc_global_phred_scores.py

--- a/docker/util/Dockerfile
+++ b/docker/util/Dockerfile
@@ -4,7 +4,8 @@ RUN apt-get update \
     && apt-get upgrade -y \
     &&  apt-get install wget zip gcc zlib1g-dev libbz2-dev \
       liblzma-dev jq python3 python3-pip parallel \
-      python3-csvkit python3-pysam -y \
+      python3-csvkit python3-pysam python3-gtfparse -y \
     && rm -r /var/lib/apt/lists/*
 
 COPY --from=scripts --chmod=777 util/calc_global_phred_scores.py /scripts/util/calc_global_phred_scores.py
+COPY --from=scripts --chmod=777 util/calc_gene_lengths.py /scripts/util/calc_gene_lengths.py

--- a/docker/util/package.json
+++ b/docker/util/package.json
@@ -1,4 +1,4 @@
 {
     "name": "util",
-    "version": "2.0.0"
+    "version": "2.1.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ numpy==1.26.4
 matplotlib==3.8.4
 umap-learn==0.5.7
 pysam==0.21.0
-gtfparse==1.2.1
+gtfparse==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas==1.5.2
 numpy==1.26.4
 matplotlib==3.8.4
 umap-learn==0.5.7
+pysam==0.21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy==1.26.4
 matplotlib==3.8.4
 umap-learn==0.5.7
 pysam==0.21.0
+gtfparse==1.2.1

--- a/scripts/CHANGELOG.md
+++ b/scripts/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 Any change to the `scripts/` directory should be accompanied by version increases in the `docker/` directory! If you are editing this file, please ensure these changes propagate!
 
+## 2025 February
+
+### Added
+
+- Added `calc_global_phred_scores.py` script [#216](https://github.com/stjudecloud/workflows/pull/216).
+
 ## 2025 January
 
 ### Added

--- a/scripts/CHANGELOG.md
+++ b/scripts/CHANGELOG.md
@@ -12,7 +12,7 @@ Any change to the `scripts/` directory should be accompanied by version increase
 
 ### Added
 
-- Added `calc_global_phred_scores.py` script [#216](https://github.com/stjudecloud/workflows/pull/216).
+- Added `calc_global_phred_scores.py` and `calc_gene_lengths.py` scripts [#216](https://github.com/stjudecloud/workflows/pull/216).
 
 ## 2025 January
 

--- a/scripts/util/calc_gene_lengths.py
+++ b/scripts/util/calc_gene_lengths.py
@@ -27,8 +27,9 @@ def main(gtf_path, outfile_path, id_attr):
             gene_end_offset[feature_id] = end
         else:
             gene_start_offset[feature_id] = min(
-                gene_start_offset[feature_id], start
-            )  # pyright: ignore [reportArgumentType]
+                gene_start_offset[feature_id],
+                start,  # pyright: ignore [reportArgumentType]
+            )
             gene_end_offset[feature_id] = max(gene_end_offset[feature_id], end)
 
     for feature_id in exon_starts:

--- a/scripts/util/calc_gene_lengths.py
+++ b/scripts/util/calc_gene_lengths.py
@@ -13,7 +13,10 @@ def main(gtf_path, outfile_path, id_attr):
     gene_end_offset = {}
     gene_exon_intersection = {}
 
-    for _index, value in only_exons.iterrows():
+    for (
+        _index,
+        value,
+    ) in only_exons.iterrows():  # pyright: ignore [reportAttributeAccessIssue]
         feature_id = value[id_attr]
         start = value["start"]
         end = value["end"] + 1  # end is inclusive in GTF
@@ -23,7 +26,9 @@ def main(gtf_path, outfile_path, id_attr):
             gene_start_offset[feature_id] = start
             gene_end_offset[feature_id] = end
         else:
-            gene_start_offset[feature_id] = min(gene_start_offset[feature_id], start)
+            gene_start_offset[feature_id] = min(
+                gene_start_offset[feature_id], start
+            )  # pyright: ignore [reportArgumentType]
             gene_end_offset[feature_id] = max(gene_end_offset[feature_id], end)
 
     for feature_id in exon_starts:

--- a/scripts/util/calc_gene_lengths.py
+++ b/scripts/util/calc_gene_lengths.py
@@ -1,0 +1,62 @@
+import gtfparse
+import numpy as np
+from collections import defaultdict
+
+
+def main(gtf_path, outfile_path, id_attr):
+    gtf = gtfparse.read_gtf(gtf_path)
+
+    only_exons = gtf[gtf["feature"] == "exon"]
+    exon_starts = defaultdict(lambda: [])
+    exon_ends = defaultdict(lambda: [])
+    gene_start_offset = {}
+    gene_end_offset = {}
+    gene_exon_intersection = {}
+
+    for _index, value in only_exons.iterrows():
+        feature_id = value[id_attr]
+        start = value["start"]
+        end = value["end"] + 1  # end is inclusive in GTF
+        exon_starts[feature_id].append(start)
+        exon_ends[feature_id].append(end)
+        if feature_id not in gene_start_offset:
+            gene_start_offset[feature_id] = start
+            gene_end_offset[feature_id] = end
+        else:
+            gene_start_offset[feature_id] = min(gene_start_offset[feature_id], start)
+            gene_end_offset[feature_id] = max(gene_end_offset[feature_id], end)
+
+    for feature_id in exon_starts:
+        gene_exon_intersection[feature_id] = np.full(
+            gene_end_offset[feature_id] - gene_start_offset[feature_id], False
+        )
+
+        for start, end in zip(exon_starts[feature_id], exon_ends[feature_id]):
+            gene_exon_intersection[feature_id][
+                start
+                - gene_start_offset[feature_id] : end
+                - gene_start_offset[feature_id]
+            ] = True
+
+    outfile = open(outfile_path, "w")
+    print("feature\tlength", file=outfile)
+    for gene, exonic_intersection in sorted(gene_exon_intersection.items()):
+        # np.count_nonzero() is faster than sum
+        # np.count_nonzero() evaluates the "truthfulness" of
+        # of all elements (by calling their '.__bool__()' method)
+        length = np.count_nonzero(exonic_intersection)
+        print(f"{gene}\t{length}", file=outfile)
+
+    outfile.close()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("gtf_path", type=str)
+    parser.add_argument("outfile_path", type=str)
+    parser.add_argument("--id_attr", type=str, default="gene_name")
+
+    args = parser.parse_args()
+    main(args.gtf_path, args.outfile_path, args.id_attr)

--- a/scripts/util/calc_global_phred_scores.py
+++ b/scripts/util/calc_global_phred_scores.py
@@ -21,6 +21,7 @@ def stats_from_dict(score_dict):
     median_pos = (total_freq + 1) / 2
     cumul_freq = 0
     median_found = False
+    median = None
     sum_freq_times_score_sqrd = 0
     for score, freq in freq_table:
         cumul_freq += freq
@@ -38,10 +39,9 @@ def stats_from_dict(score_dict):
 def main(bam_path, prefix, fast_mode):
     bam = pysam.AlignmentFile(bam_path, "rb")
 
-    if not fast_mode:
-        tot_quals = defaultdict(lambda: 0)
-        mapped_quals = defaultdict(lambda: 0)
-        unmapped_quals = defaultdict(lambda: 0)
+    tot_quals = defaultdict(lambda: 0)
+    mapped_quals = defaultdict(lambda: 0)
+    unmapped_quals = defaultdict(lambda: 0)
     first_tot_quals = defaultdict(lambda: 0)
     first_mapped_quals = defaultdict(lambda: 0)
     first_unmapped_quals = defaultdict(lambda: 0)

--- a/scripts/util/calc_global_phred_scores.py
+++ b/scripts/util/calc_global_phred_scores.py
@@ -232,7 +232,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--fast_mode",
         action="store_true",
-        help="Only calculate the first, middle, and last position PHRED scores isntead of also calculating PHRED scores for _every_ position",
+        help="Only calculate the first, middle, and last position PHRED scores instead of also calculating PHRED scores for _every_ position",
     )
     args = parser.parse_args()
 

--- a/scripts/util/calc_global_phred_scores.py
+++ b/scripts/util/calc_global_phred_scores.py
@@ -232,7 +232,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--fast_mode",
         action="store_true",
-        help="Only calculate the average, median, and standard deviation of the global PHRED scores",
+        help="Only calculate the first, middle, and last position PHRED scores isntead of also calculating PHRED scores for _every_ position",
     )
     args = parser.parse_args()
 

--- a/scripts/util/calc_global_phred_scores.py
+++ b/scripts/util/calc_global_phred_scores.py
@@ -184,9 +184,11 @@ def main(bam_path, prefix, fast_mode):
     print(f"{middle_mapped_median}", file=outfile, end="\t")
     print(f"{middle_mapped_stdev}", file=outfile, end="\t")
 
-    middle_unmapped_avg, middle_unmapped_median, middle_unmapped_stdev = (
-        stats_from_dict(middle_unmapped_quals)
-    )
+    (
+        middle_unmapped_avg,
+        middle_unmapped_median,
+        middle_unmapped_stdev,
+    ) = stats_from_dict(middle_unmapped_quals)
     print(f"{middle_unmapped_avg}", file=outfile, end="\t")
     print(f"{middle_unmapped_median}", file=outfile, end="\t")
     print(f"{middle_unmapped_stdev}", file=outfile, end="\t")

--- a/scripts/util/calc_global_phred_scores.py
+++ b/scripts/util/calc_global_phred_scores.py
@@ -1,0 +1,235 @@
+from collections import defaultdict
+
+import pysam
+
+
+def main(bam_path, prefix, fast_mode):
+    bam = pysam.AlignmentFile(bam_path, "rb")
+
+    if not fast_mode:
+        tot_quals = defaultdict(lambda: 0)
+        mapped_quals = defaultdict(lambda: 0)
+        unmapped_quals = defaultdict(lambda: 0)
+    first_tot_quals = defaultdict(lambda: 0)
+    first_mapped_quals = defaultdict(lambda: 0)
+    first_unmapped_quals = defaultdict(lambda: 0)
+    middle_tot_quals = defaultdict(lambda: 0)
+    middle_mapped_quals = defaultdict(lambda: 0)
+    middle_unmapped_quals = defaultdict(lambda: 0)
+    last_tot_quals = defaultdict(lambda: 0)
+    last_mapped_quals = defaultdict(lambda: 0)
+    last_unmapped_quals = defaultdict(lambda: 0)
+    for read in bam:
+        # only count primary alignments and unmapped reads
+        if (read.is_secondary or read.is_supplementary) and not read.is_unmapped:
+            continue
+
+        cur_quals = read.query_qualities  # array of phred scores
+        if not fast_mode:
+            for qual in cur_quals:
+                tot_quals[qual] += 1
+                if read.is_unmapped:
+                    unmapped_quals[qual] += 1
+                else:
+                    mapped_quals[qual] += 1
+
+        first_score = cur_quals[0]
+        first_tot_quals[first_score] += 1
+
+        middle_pos = len(cur_quals) // 2  # middle base of read
+        middle_score = cur_quals[middle_pos]
+        middle_tot_quals[middle_score] += 1
+
+        last_score = cur_quals[-1]
+        last_tot_quals[last_score] += 1
+
+        if read.is_unmapped:
+            first_unmapped_quals[first_score] += 1
+            middle_unmapped_quals[middle_score] += 1
+            last_unmapped_quals[last_score] += 1
+        else:
+            first_mapped_quals[first_score] += 1
+            middle_mapped_quals[middle_score] += 1
+            last_mapped_quals[last_score] += 1
+
+    outfile = open(prefix + ".global_PHRED_scores.tsv", "w")
+
+    # print header
+    header = ["sample"]
+    if not fast_mode:
+        header += [
+            "total average",
+            "total median",
+            "total stdev",
+            "mapped average",
+            "mapped median",
+            "mapped stdev",
+            "unmapped average",
+            "unmapped median",
+            "unmapped stdev",
+        ]
+    header += [
+        "first position total average",
+        "first position total median",
+        "first position total stdev",
+        "first position mapped average",
+        "first position mapped median",
+        "first position mapped stdev",
+        "first position unmapped average",
+        "first position unmapped median",
+        "first position unmapped stdev",
+        "middle position total average",
+        "middle position total median",
+        "middle position total stdev",
+        "middle position mapped average",
+        "middle position mapped median",
+        "middle position mapped stdev",
+        "middle position unmapped average",
+        "middle position unmapped median",
+        "middle position unmapped stdev",
+        "last position total average",
+        "last position total median",
+        "last position total stdev",
+        "last position mapped average",
+        "last position mapped median",
+        "last position mapped stdev",
+        "last position unmapped average",
+        "last position unmapped median",
+        "last position unmapped stdev",
+    ]
+    print(
+        "\t".join(header),
+        file=outfile,
+    )
+    print(prefix, file=outfile, end="\t")
+
+
+    def stats_from_dict(score_dict):
+        total_score = 0
+        total_freq = 0
+        freq_table = []
+        for score, freq in score_dict.items():
+            total_score += score * freq
+            total_freq += freq
+            freq_table.append((score, freq))
+
+        if total_freq == 0:
+            return -1, -1, -1
+        avg = total_score / total_freq
+
+        freq_table.sort(key=lambda entry: entry[0])
+
+        median_pos = (total_freq + 1) / 2
+        cumul_freq = 0
+        median_found = False
+        sum_freq_times_score_sqrd = 0
+        for score, freq in freq_table:
+            cumul_freq += freq
+            if cumul_freq >= median_pos:
+                if not median_found:
+                    median = score
+                median_found = True
+            sum_freq_times_score_sqrd += freq * (score**2)
+
+        stdev = ((sum_freq_times_score_sqrd / total_freq) - (avg**2)) ** 0.5
+
+        return avg, median, stdev
+
+
+    if not fast_mode:
+        tot_avg, tot_median, tot_stdev = stats_from_dict(tot_quals)
+        print(f"{tot_avg}", file=outfile, end="\t")
+        print(f"{tot_median}", file=outfile, end="\t")
+        print(f"{tot_stdev}", file=outfile, end="\t")
+
+        mapped_avg, mapped_median, mapped_stdev = stats_from_dict(mapped_quals)
+        print(f"{mapped_avg}", file=outfile, end="\t")
+        print(f"{mapped_median}", file=outfile, end="\t")
+        print(f"{mapped_stdev}", file=outfile, end="\t")
+
+        unmapped_avg, unmapped_median, unmapped_stdev = stats_from_dict(unmapped_quals)
+        print(f"{unmapped_avg}", file=outfile, end="\t")
+        print(f"{unmapped_median}", file=outfile, end="\t")
+        print(f"{unmapped_stdev}", file=outfile, end="\t")
+
+    first_tot_avg, first_tot_median, first_tot_stdev = stats_from_dict(first_tot_quals)
+    print(f"{first_tot_avg}", file=outfile, end="\t")
+    print(f"{first_tot_median}", file=outfile, end="\t")
+    print(f"{first_tot_stdev}", file=outfile, end="\t")
+
+    first_mapped_avg, first_mapped_median, first_mapped_stdev = stats_from_dict(
+        first_mapped_quals
+    )
+    print(f"{first_mapped_avg}", file=outfile, end="\t")
+    print(f"{first_mapped_median}", file=outfile, end="\t")
+    print(f"{first_mapped_stdev}", file=outfile, end="\t")
+
+    first_unmapped_avg, first_unmapped_median, first_unmapped_stdev = stats_from_dict(
+        first_unmapped_quals
+    )
+    print(f"{first_unmapped_avg}", file=outfile, end="\t")
+    print(f"{first_unmapped_median}", file=outfile, end="\t")
+    print(f"{first_unmapped_stdev}", file=outfile, end="\t")
+
+    middle_tot_avg, middle_tot_median, middle_tot_stdev = stats_from_dict(middle_tot_quals)
+    print(f"{middle_tot_avg}", file=outfile, end="\t")
+    print(f"{middle_tot_median}", file=outfile, end="\t")
+    print(f"{middle_tot_stdev}", file=outfile, end="\t")
+
+    middle_mapped_avg, middle_mapped_median, middle_mapped_stdev = stats_from_dict(
+        middle_mapped_quals
+    )
+    print(f"{middle_mapped_avg}", file=outfile, end="\t")
+    print(f"{middle_mapped_median}", file=outfile, end="\t")
+    print(f"{middle_mapped_stdev}", file=outfile, end="\t")
+
+    middle_unmapped_avg, middle_unmapped_median, middle_unmapped_stdev = stats_from_dict(
+        middle_unmapped_quals
+    )
+    print(f"{middle_unmapped_avg}", file=outfile, end="\t")
+    print(f"{middle_unmapped_median}", file=outfile, end="\t")
+    print(f"{middle_unmapped_stdev}", file=outfile, end="\t")
+
+    last_tot_avg, last_tot_median, last_tot_stdev = stats_from_dict(last_tot_quals)
+    print(f"{last_tot_avg}", file=outfile, end="\t")
+    print(f"{last_tot_median}", file=outfile, end="\t")
+    print(f"{last_tot_stdev}", file=outfile, end="\t")
+
+    last_mapped_avg, last_mapped_median, last_mapped_stdev = stats_from_dict(
+        last_mapped_quals
+    )
+    print(f"{last_mapped_avg}", file=outfile, end="\t")
+    print(f"{last_mapped_median}", file=outfile, end="\t")
+    print(f"{last_mapped_stdev}", file=outfile, end="\t")
+
+    last_unmapped_avg, last_unmapped_median, last_unmapped_stdev = stats_from_dict(
+        last_unmapped_quals
+    )
+    print(f"{last_unmapped_avg}", file=outfile, end="\t")
+    print(f"{last_unmapped_median}", file=outfile, end="\t")
+    print(f"{last_unmapped_stdev}", file=outfile)  # end="\n"
+
+    outfile.close()
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "bam_path",
+        type=str,
+        help="Path to the BAM file to calculate global PHRED scores for",
+    )
+    parser.add_argument(
+        "prefix",
+        type=str,
+        help="Prefix for the output file",
+    )
+    parser.add_argument(
+        "--fast_mode",
+        action="store_true",
+        help="Only calculate the average, median, and standard deviation of the global PHRED scores",
+    )
+    args = parser.parse_args()
+
+    main(args.bam_path, args.prefix, args.fast_mode)

--- a/tests/tools/test_util.yaml
+++ b/tests/tools/test_util.yaml
@@ -39,7 +39,6 @@
       must_not_contain:
         - "@RG"
 
-
 - name: split_string
   tags:
     - miniwdl

--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
+
+## 2025 February
+
+### Changed
+
+- `ngsderive.encoding` removed the `String inferred_encoding` output [#216](https://github.com/stjudecloud/workflows/pull/216).
  
 ## 2025 January
 

--- a/tools/bwa.wdl
+++ b/tools/bwa.wdl
@@ -86,7 +86,7 @@ task bwa_aln {
         cpu: ncpu
         memory: "5 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/bwa:0.7.17-2"
+        container: "ghcr.io/stjudecloud/bwa:branch-scripts-0.7.17-2"
         maxRetries: 1
     }
 }
@@ -187,7 +187,7 @@ task bwa_aln_pe {
         cpu: ncpu
         memory: "17 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/bwa:0.7.17-2"
+        container: "ghcr.io/stjudecloud/bwa:branch-scripts-0.7.17-2"
         maxRetries: 1
     }
 }
@@ -283,7 +283,7 @@ task bwa_mem {
         cpu: ncpu
         memory: "25 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/bwa:0.7.17-2"
+        container: "ghcr.io/stjudecloud/bwa:branch-scripts-0.7.17-2"
         maxRetries: 1
     }
 }
@@ -334,7 +334,7 @@ task build_bwa_db {
     runtime {
         memory: "5 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/bwa:0.7.17-2"
+        container: "ghcr.io/stjudecloud/bwa:branch-scripts-0.7.17-2"
         maxRetries: 1
     }
 }

--- a/tools/bwa.wdl
+++ b/tools/bwa.wdl
@@ -86,7 +86,7 @@ task bwa_aln {
         cpu: ncpu
         memory: "5 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/bwa:branch-scripts-0.7.17-2"
+        container: "ghcr.io/stjudecloud/bwa:0.7.17-2"
         maxRetries: 1
     }
 }
@@ -187,7 +187,7 @@ task bwa_aln_pe {
         cpu: ncpu
         memory: "17 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/bwa:branch-scripts-0.7.17-2"
+        container: "ghcr.io/stjudecloud/bwa:0.7.17-2"
         maxRetries: 1
     }
 }
@@ -283,7 +283,7 @@ task bwa_mem {
         cpu: ncpu
         memory: "25 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/bwa:branch-scripts-0.7.17-2"
+        container: "ghcr.io/stjudecloud/bwa:0.7.17-2"
         maxRetries: 1
     }
 }
@@ -334,7 +334,7 @@ task build_bwa_db {
     runtime {
         memory: "5 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/bwa:branch-scripts-0.7.17-2"
+        container: "ghcr.io/stjudecloud/bwa:0.7.17-2"
         maxRetries: 1
     }
 }

--- a/tools/estimate.wdl
+++ b/tools/estimate.wdl
@@ -51,7 +51,7 @@ task run_estimate {
     runtime {
         memory: "~{memory_gb} GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/estimate:branch-scripts-2.0.0"
+        container: "ghcr.io/stjudecloud/estimate:2.0.0"
         maxRetries: max_retries
     }
 }

--- a/tools/estimate.wdl
+++ b/tools/estimate.wdl
@@ -51,7 +51,7 @@ task run_estimate {
     runtime {
         memory: "~{memory_gb} GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/estimate:2.0.0"
+        container: "ghcr.io/stjudecloud/estimate:branch-scripts-2.0.0"
         maxRetries: max_retries
     }
 }

--- a/tools/htseq.wdl
+++ b/tools/htseq.wdl
@@ -209,7 +209,7 @@ task calc_tpm {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:2.1.0"
+        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
         maxRetries: 1
     }
 }

--- a/tools/htseq.wdl
+++ b/tools/htseq.wdl
@@ -209,7 +209,7 @@ task calc_tpm {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:2.0.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }

--- a/tools/htseq.wdl
+++ b/tools/htseq.wdl
@@ -209,7 +209,7 @@ task calc_tpm {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }

--- a/tools/md5sum.wdl
+++ b/tools/md5sum.wdl
@@ -36,7 +36,7 @@ task compute_checksum {
     runtime {
         memory: "4 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }

--- a/tools/md5sum.wdl
+++ b/tools/md5sum.wdl
@@ -36,7 +36,7 @@ task compute_checksum {
     runtime {
         memory: "4 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/util:2.1.0"
+        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
         maxRetries: 1
     }
 }

--- a/tools/md5sum.wdl
+++ b/tools/md5sum.wdl
@@ -36,7 +36,7 @@ task compute_checksum {
     runtime {
         memory: "4 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/util:2.0.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }

--- a/tools/ngsderive.wdl
+++ b/tools/ngsderive.wdl
@@ -210,7 +210,6 @@ task encoding {
     meta {
         description: "Derives the encoding of the input NGS file(s). Reports evidence supporting final results."
         outputs: {
-            inferred_encoding: "The most permissive encoding found among the input files, in string format",
             encoding_file: "TSV file containing the `ngsderive encoding` report for all input files",
         }
     }
@@ -237,41 +236,13 @@ task encoding {
 
     #@ except: LineWidth
     command <<<
-        set -euo pipefail
-
         ngsderive encoding --verbose \
             -n ~{num_reads} \
             ~{sep(" ", ngs_files)} \
             > ~{outfile_name}
-
-        ENCODING_FILE="~{outfile_name}" python - <<END
-        import os  # lint-check: ignore
-
-        encoding_file = open(os.environ['ENCODING_FILE'], 'r')
-        encoding_file.readline()  # discard header
-        permissive_encoding = ""
-        for line in encoding_file:
-            contents = line.strip().split('\t')
-            cur_encoding = contents[2]
-            if cur_encoding == "Unkown":
-                permissive_encoding = cur_encoding
-                break
-            if cur_encoding == "Sanger/Illumina 1.8" or permissive_encoding == "Sanger/Illumina 1.8":
-                permissive_encoding = "Sanger/Illumina 1.8"
-            elif cur_encoding == "Solexa/Illumina 1.0" or permissive_encoding == "Solexa/Illumina 1.0":
-                permissive_encoding = "Solexa/Illumina 1.0"
-            elif cur_encoding == "Illumina 1.3":
-                permissive_encoding = "Illumina 1.3"
-
-        outfile = open("encoding.txt", "w")
-        outfile.write(permissive_encoding)
-        outfile.close()
-
-        END
     >>>
 
     output {
-        String inferred_encoding = read_string("encoding.txt")
         File encoding_file = outfile_name
     }
 

--- a/tools/star.wdl
+++ b/tools/star.wdl
@@ -127,7 +127,7 @@ task build_star_db {
         cpu: ncpu
         memory: "~{memory_gb} GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/star:2.7.11b-5"
+        container: "ghcr.io/stjudecloud/star:2.7.11b-6"
         maxRetries: 1
     }
 }
@@ -833,7 +833,7 @@ task alignment {
         cpu: ncpu
         memory: "50 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/star:2.7.11b-5"
+        container: "ghcr.io/stjudecloud/star:2.7.11b-6"
         maxRetries: 1
     }
 }

--- a/tools/star.wdl
+++ b/tools/star.wdl
@@ -127,7 +127,7 @@ task build_star_db {
         cpu: ncpu
         memory: "~{memory_gb} GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/star:branch-scripts-2.7.11b-6"
+        container: "ghcr.io/stjudecloud/star:2.7.11b-6"
         maxRetries: 1
     }
 }
@@ -833,7 +833,7 @@ task alignment {
         cpu: ncpu
         memory: "50 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/star:branch-scripts-2.7.11b-6"
+        container: "ghcr.io/stjudecloud/star:2.7.11b-6"
         maxRetries: 1
     }
 }

--- a/tools/star.wdl
+++ b/tools/star.wdl
@@ -640,7 +640,7 @@ task alignment {
         mkdir star_db
         tar -xzf ~{star_db_tar_gz} -C star_db/ --no-same-owner
 
-        python3 /home/sort_star_input.py \
+        python3 /scripts/star/sort_star_input.py \
             --read-one-fastqs "~{sep(",", read_one_fastqs_gz)}" \
             ~{(
                 if (length(read_two_fastqs_gz) != 0)

--- a/tools/star.wdl
+++ b/tools/star.wdl
@@ -127,7 +127,7 @@ task build_star_db {
         cpu: ncpu
         memory: "~{memory_gb} GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/star:2.7.11b-6"
+        container: "ghcr.io/stjudecloud/star:branch-scripts-2.7.11b-6"
         maxRetries: 1
     }
 }
@@ -833,7 +833,7 @@ task alignment {
         cpu: ncpu
         memory: "50 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/star:2.7.11b-6"
+        container: "ghcr.io/stjudecloud/star:branch-scripts-2.7.11b-6"
         maxRetries: 1
     }
 }

--- a/tools/util.wdl
+++ b/tools/util.wdl
@@ -42,7 +42,7 @@ task download {
     runtime {
         memory: "4 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }
@@ -139,7 +139,7 @@ task split_string {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }
@@ -187,7 +187,7 @@ task calc_gene_lengths {
     runtime {
         memory: "16 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }
@@ -313,7 +313,7 @@ task unpack_tarball {
     runtime {
         memory: "4 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }
@@ -419,7 +419,7 @@ task global_phred_scores {
     runtime {
         memory: "4 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }
@@ -497,7 +497,7 @@ task qc_summary {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }
@@ -558,7 +558,7 @@ task split_fastq {
         cpu: ncpu
         memory: "4 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }

--- a/tools/util.wdl
+++ b/tools/util.wdl
@@ -309,6 +309,8 @@ task add_to_bam_header {
     String outfile_name = prefix + ".bam"
 
     command <<<
+        set -euo pipefail
+
         samtools view -H ~{bam} > header.sam
         echo "~{additional_header}" >> header.sam
         samtools reheader -P header.sam ~{bam} > ~{outfile_name}
@@ -456,8 +458,6 @@ task global_phred_scores {
 
     #@ except: LineWidth
     command <<<
-        set -euo pipefail
-
         python3 /scripts/util/calc_global_phred_scores.py \
             ~{if fast_mode then "--fast_mode" else ""} \
             ~{bam} \

--- a/tools/util.wdl
+++ b/tools/util.wdl
@@ -42,7 +42,7 @@ task download {
     runtime {
         memory: "4 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/util:2.0.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }
@@ -139,7 +139,7 @@ task split_string {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:2.0.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }
@@ -363,7 +363,7 @@ task unpack_tarball {
     runtime {
         memory: "4 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/util:2.0.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }
@@ -458,222 +458,10 @@ task global_phred_scores {
     command <<<
         set -euo pipefail
 
-        BAM="~{bam}" PREFIX="~{prefix}" FAST_MODE=~{fast_mode} python3 - <<END
-        import os  # lint-check: ignore
-        from collections import defaultdict  # lint-check: ignore
-
-        import pysam  # lint-check: ignore
-
-        bam_path = os.environ["BAM"]
-        bam = pysam.AlignmentFile(bam_path, "rb")
-
-        fast_mode = os.environ["FAST_MODE"] == "true"
-
-        if not fast_mode:
-            tot_quals = defaultdict(lambda: 0)
-            mapped_quals = defaultdict(lambda: 0)
-            unmapped_quals = defaultdict(lambda: 0)
-        first_tot_quals = defaultdict(lambda: 0)
-        first_mapped_quals = defaultdict(lambda: 0)
-        first_unmapped_quals = defaultdict(lambda: 0)
-        middle_tot_quals = defaultdict(lambda: 0)
-        middle_mapped_quals = defaultdict(lambda: 0)
-        middle_unmapped_quals = defaultdict(lambda: 0)
-        last_tot_quals = defaultdict(lambda: 0)
-        last_mapped_quals = defaultdict(lambda: 0)
-        last_unmapped_quals = defaultdict(lambda: 0)
-        for read in bam:
-            # only count primary alignments and unmapped reads
-            if (read.is_secondary or read.is_supplementary) and not read.is_unmapped:
-                continue
-
-            cur_quals = read.query_qualities  # array of phred scores
-            if not fast_mode:
-                for qual in cur_quals:
-                    tot_quals[qual] += 1
-                    if read.is_unmapped:
-                        unmapped_quals[qual] += 1
-                    else:
-                        mapped_quals[qual] += 1
-
-            first_score = cur_quals[0]
-            first_tot_quals[first_score] += 1
-
-            middle_pos = len(cur_quals) // 2  # middle base of read
-            middle_score = cur_quals[middle_pos]
-            middle_tot_quals[middle_score] += 1
-
-            last_score = cur_quals[-1]
-            last_tot_quals[last_score] += 1
-
-            if read.is_unmapped:
-                first_unmapped_quals[first_score] += 1
-                middle_unmapped_quals[middle_score] += 1
-                last_unmapped_quals[last_score] += 1
-            else:
-                first_mapped_quals[first_score] += 1
-                middle_mapped_quals[middle_score] += 1
-                last_mapped_quals[last_score] += 1
-
-        prefix = os.environ["PREFIX"]
-        outfile = open(prefix + ".global_PHRED_scores.tsv", "w")
-
-        # print header
-        header = ["sample"]
-        if not fast_mode:
-            header += [
-                "total average",
-                "total median",
-                "total stdev",
-                "mapped average",
-                "mapped median",
-                "mapped stdev",
-                "unmapped average",
-                "unmapped median",
-                "unmapped stdev",
-            ]
-        header += [
-            "first position total average",
-            "first position total median",
-            "first position total stdev",
-            "first position mapped average",
-            "first position mapped median",
-            "first position mapped stdev",
-            "first position unmapped average",
-            "first position unmapped median",
-            "first position unmapped stdev",
-            "middle position total average",
-            "middle position total median",
-            "middle position total stdev",
-            "middle position mapped average",
-            "middle position mapped median",
-            "middle position mapped stdev",
-            "middle position unmapped average",
-            "middle position unmapped median",
-            "middle position unmapped stdev",
-            "last position total average",
-            "last position total median",
-            "last position total stdev",
-            "last position mapped average",
-            "last position mapped median",
-            "last position mapped stdev",
-            "last position unmapped average",
-            "last position unmapped median",
-            "last position unmapped stdev",
-        ]
-        print(
-            "\t".join(header),
-            file=outfile,
-        )
-        print(prefix, file=outfile, end="\t")
-
-        def stats_from_dict(score_dict):
-            total_score = 0
-            total_freq = 0
-            freq_table = []
-            for score, freq in score_dict.items():
-                total_score += score * freq
-                total_freq += freq
-                freq_table.append((score, freq))
-
-            if total_freq == 0:
-                return -1, -1, -1
-            avg = total_score / total_freq
-
-            freq_table.sort(key=lambda entry: entry[0])
-
-            median_pos = (total_freq + 1) / 2
-            cumul_freq = 0
-            median_found = False
-            sum_freq_times_score_sqrd = 0
-            for score, freq in freq_table:
-                cumul_freq += freq
-                if cumul_freq >= median_pos:
-                    if not median_found:
-                        median = score
-                    median_found = True
-                sum_freq_times_score_sqrd += freq * (score**2)
-
-            stdev = ((sum_freq_times_score_sqrd / total_freq) - (avg**2)) ** 0.5
-
-            return avg, median, stdev
-
-        if not fast_mode:
-            tot_avg, tot_median, tot_stdev = stats_from_dict(tot_quals)
-            print(f"{tot_avg}", file=outfile, end="\t")
-            print(f"{tot_median}", file=outfile, end="\t")
-            print(f"{tot_stdev}", file=outfile, end="\t")
-
-            mapped_avg, mapped_median, mapped_stdev = stats_from_dict(mapped_quals)
-            print(f"{mapped_avg}", file=outfile, end="\t")
-            print(f"{mapped_median}", file=outfile, end="\t")
-            print(f"{mapped_stdev}", file=outfile, end="\t")
-
-            unmapped_avg, unmapped_median, unmapped_stdev = stats_from_dict(unmapped_quals)
-            print(f"{unmapped_avg}", file=outfile, end="\t")
-            print(f"{unmapped_median}", file=outfile, end="\t")
-            print(f"{unmapped_stdev}", file=outfile, end="\t")
-
-        first_tot_avg, first_tot_median, first_tot_stdev = stats_from_dict(first_tot_quals)
-        print(f"{first_tot_avg}", file=outfile, end="\t")
-        print(f"{first_tot_median}", file=outfile, end="\t")
-        print(f"{first_tot_stdev}", file=outfile, end="\t")
-
-        first_mapped_avg, first_mapped_median, first_mapped_stdev = stats_from_dict(
-            first_mapped_quals
-        )
-        print(f"{first_mapped_avg}", file=outfile, end="\t")
-        print(f"{first_mapped_median}", file=outfile, end="\t")
-        print(f"{first_mapped_stdev}", file=outfile, end="\t")
-
-        first_unmapped_avg, first_unmapped_median, first_unmapped_stdev = stats_from_dict(
-            first_unmapped_quals
-        )
-        print(f"{first_unmapped_avg}", file=outfile, end="\t")
-        print(f"{first_unmapped_median}", file=outfile, end="\t")
-        print(f"{first_unmapped_stdev}", file=outfile, end="\t")
-
-        middle_tot_avg, middle_tot_median, middle_tot_stdev = stats_from_dict(middle_tot_quals)
-        print(f"{middle_tot_avg}", file=outfile, end="\t")
-        print(f"{middle_tot_median}", file=outfile, end="\t")
-        print(f"{middle_tot_stdev}", file=outfile, end="\t")
-
-        middle_mapped_avg, middle_mapped_median, middle_mapped_stdev = stats_from_dict(
-            middle_mapped_quals
-        )
-        print(f"{middle_mapped_avg}", file=outfile, end="\t")
-        print(f"{middle_mapped_median}", file=outfile, end="\t")
-        print(f"{middle_mapped_stdev}", file=outfile, end="\t")
-
-        middle_unmapped_avg, middle_unmapped_median, middle_unmapped_stdev = stats_from_dict(
-            middle_unmapped_quals
-        )
-        print(f"{middle_unmapped_avg}", file=outfile, end="\t")
-        print(f"{middle_unmapped_median}", file=outfile, end="\t")
-        print(f"{middle_unmapped_stdev}", file=outfile, end="\t")
-
-        last_tot_avg, last_tot_median, last_tot_stdev = stats_from_dict(last_tot_quals)
-        print(f"{last_tot_avg}", file=outfile, end="\t")
-        print(f"{last_tot_median}", file=outfile, end="\t")
-        print(f"{last_tot_stdev}", file=outfile, end="\t")
-
-        last_mapped_avg, last_mapped_median, last_mapped_stdev = stats_from_dict(
-            last_mapped_quals
-        )
-        print(f"{last_mapped_avg}", file=outfile, end="\t")
-        print(f"{last_mapped_median}", file=outfile, end="\t")
-        print(f"{last_mapped_stdev}", file=outfile, end="\t")
-
-        last_unmapped_avg, last_unmapped_median, last_unmapped_stdev = stats_from_dict(
-            last_unmapped_quals
-        )
-        print(f"{last_unmapped_avg}", file=outfile, end="\t")
-        print(f"{last_unmapped_median}", file=outfile, end="\t")
-        print(f"{last_unmapped_stdev}", file=outfile)  # end="\n"
-
-        outfile.close()
-
-        END
+        python3 /scripts/util/calc_global_phred_scores.py \
+            --bam ~{bam} \
+            --prefix ~{prefix} \
+            ~{if fast_mode then "--fast-mode" else ""}
     >>>
 
     output {
@@ -683,7 +471,7 @@ task global_phred_scores {
     runtime {
         memory: "4 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/util:2.0.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }
@@ -761,7 +549,7 @@ task qc_summary {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:2.0.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }
@@ -822,7 +610,7 @@ task split_fastq {
         cpu: ncpu
         memory: "4 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/util:2.0.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }

--- a/tools/util.wdl
+++ b/tools/util.wdl
@@ -459,9 +459,9 @@ task global_phred_scores {
         set -euo pipefail
 
         python3 /scripts/util/calc_global_phred_scores.py \
-            --bam ~{bam} \
-            --prefix ~{prefix} \
             ~{if fast_mode then "--fast-mode" else ""}
+            ~{bam} \
+            ~{prefix} \
     >>>
 
     output {

--- a/tools/util.wdl
+++ b/tools/util.wdl
@@ -459,7 +459,7 @@ task global_phred_scores {
         set -euo pipefail
 
         python3 /scripts/util/calc_global_phred_scores.py \
-            ~{if fast_mode then "--fast-mode" else ""} \
+            ~{if fast_mode then "--fast_mode" else ""} \
             ~{bam} \
             ~{prefix}
     >>>

--- a/tools/util.wdl
+++ b/tools/util.wdl
@@ -459,9 +459,9 @@ task global_phred_scores {
         set -euo pipefail
 
         python3 /scripts/util/calc_global_phred_scores.py \
-            ~{if fast_mode then "--fast-mode" else ""}
+            ~{if fast_mode then "--fast-mode" else ""} \
             ~{bam} \
-            ~{prefix} \
+            ~{prefix}
     >>>
 
     output {

--- a/tools/util.wdl
+++ b/tools/util.wdl
@@ -42,7 +42,7 @@ task download {
     runtime {
         memory: "4 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/util:2.1.0"
+        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
         maxRetries: 1
     }
 }
@@ -139,7 +139,7 @@ task split_string {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:2.1.0"
+        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
         maxRetries: 1
     }
 }
@@ -363,7 +363,7 @@ task unpack_tarball {
     runtime {
         memory: "4 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/util:2.1.0"
+        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
         maxRetries: 1
     }
 }
@@ -471,7 +471,7 @@ task global_phred_scores {
     runtime {
         memory: "4 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/util:2.1.0"
+        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
         maxRetries: 1
     }
 }
@@ -549,7 +549,7 @@ task qc_summary {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:2.1.0"
+        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
         maxRetries: 1
     }
 }
@@ -610,7 +610,7 @@ task split_fastq {
         cpu: ncpu
         memory: "4 GB"
         disks: "~{disk_size_gb} GB"
-        container: "ghcr.io/stjudecloud/util:2.1.0"
+        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
         maxRetries: 1
     }
 }

--- a/workflows/dnaseq/dnaseq-standard-fastq.wdl
+++ b/workflows/dnaseq/dnaseq-standard-fastq.wdl
@@ -159,7 +159,7 @@ task parse_input {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:2.1.0"
+        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
         maxRetries: 0
     }
 }

--- a/workflows/dnaseq/dnaseq-standard-fastq.wdl
+++ b/workflows/dnaseq/dnaseq-standard-fastq.wdl
@@ -159,7 +159,7 @@ task parse_input {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:2.0.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 0
     }
 }

--- a/workflows/dnaseq/dnaseq-standard-fastq.wdl
+++ b/workflows/dnaseq/dnaseq-standard-fastq.wdl
@@ -159,7 +159,7 @@ task parse_input {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 0
     }
 }

--- a/workflows/dnaseq/dnaseq-standard.wdl
+++ b/workflows/dnaseq/dnaseq-standard.wdl
@@ -136,7 +136,7 @@ task parse_input {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 0
     }
 }

--- a/workflows/dnaseq/dnaseq-standard.wdl
+++ b/workflows/dnaseq/dnaseq-standard.wdl
@@ -136,7 +136,7 @@ task parse_input {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:2.0.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 0
     }
 }

--- a/workflows/dnaseq/dnaseq-standard.wdl
+++ b/workflows/dnaseq/dnaseq-standard.wdl
@@ -136,7 +136,7 @@ task parse_input {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:2.1.0"
+        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
         maxRetries: 0
     }
 }

--- a/workflows/methylation/methylation-cohort.wdl
+++ b/workflows/methylation/methylation-cohort.wdl
@@ -114,7 +114,7 @@ task combine_data {
     Int disk_size_gb = ceil(size(unfiltered_normalized_beta, "GiB") * 2) + 2
 
     command <<<
-        python $(which combine.py) \
+        python /scripts/methylation/combine.py \
             --output-name ~{combined_file_name} \
             ~{sep(" ", unfiltered_normalized_beta)}
     >>>
@@ -124,7 +124,7 @@ task combine_data {
     }
 
     runtime {
-        container: "ghcr.io/stjudecloud/pandas:2.2.1-3"
+        container: "ghcr.io/stjudecloud/pandas:2.2.1-4"
         memory: "~{memory_gb} GB"
         cpu: 1
         disks: "~{disk_size_gb} GB"
@@ -157,7 +157,7 @@ task filter_probes {
     Int disk_size_gb = ceil(size(beta_values, "GiB") * 2) + 2
 
     command <<<
-        python $(which filter.py) \
+        python /scripts/methylation/filter.py \
             --output-name ~{prefix}.beta.csv \
             --filtered-probes ~{prefix}.probes.csv \
             --num-probes ~{num_probes} \
@@ -170,7 +170,7 @@ task filter_probes {
     }
 
     runtime {
-        container: "ghcr.io/stjudecloud/pandas:2.2.1-3"
+        container: "ghcr.io/stjudecloud/pandas:2.2.1-4"
         memory: "8 GB"
         cpu: 1
         disks: "~{disk_size_gb} GB"
@@ -199,7 +199,7 @@ task generate_umap {
     Int disk_size_gb = ceil(size(filtered_beta_values, "GiB") * 2) + 2
 
     command <<<
-        python /usr/local/bin/generate_umap.py \
+        python /scripts/methylation/generate_umap.py \
             --beta ~{filtered_beta_values} \
             --output-name ~{prefix}.csv
     >>>
@@ -209,7 +209,7 @@ task generate_umap {
     }
 
     runtime {
-        container: "ghcr.io/stjudecloud/umap:0.5.7-4"
+        container: "ghcr.io/stjudecloud/umap:0.5.7-5"
         memory: "8 GB"
         cpu: 1
         disks: "~{disk_size_gb} GB"
@@ -236,7 +236,7 @@ task plot_umap {
     }
 
     command <<<
-        python /usr/local/bin/plot_umap.py --umap ~{umap} --output-name ~{plot_file}
+        python /scripts/methylation/plot_umap.py --umap ~{umap} --output-name ~{plot_file}
     >>>
 
     output {
@@ -244,7 +244,7 @@ task plot_umap {
     }
 
     runtime {
-        container: "ghcr.io/stjudecloud/python-plotting:2.0.0"
+        container: "ghcr.io/stjudecloud/python-plotting:2.0.1"
         memory: "4 GB"
         cpu: 1
         disks: "4 GB"

--- a/workflows/methylation/methylation-cohort.wdl
+++ b/workflows/methylation/methylation-cohort.wdl
@@ -124,7 +124,7 @@ task combine_data {
     }
 
     runtime {
-        container: "ghcr.io/stjudecloud/pandas:branch-scripts-2.2.1-4"
+        container: "ghcr.io/stjudecloud/pandas:2.2.1-4"
         memory: "~{memory_gb} GB"
         cpu: 1
         disks: "~{disk_size_gb} GB"
@@ -170,7 +170,7 @@ task filter_probes {
     }
 
     runtime {
-        container: "ghcr.io/stjudecloud/pandas:branch-scripts-2.2.1-4"
+        container: "ghcr.io/stjudecloud/pandas:2.2.1-4"
         memory: "8 GB"
         cpu: 1
         disks: "~{disk_size_gb} GB"
@@ -209,7 +209,7 @@ task generate_umap {
     }
 
     runtime {
-        container: "ghcr.io/stjudecloud/umap:branch-scripts-0.5.7-5"
+        container: "ghcr.io/stjudecloud/umap:0.5.7-5"
         memory: "8 GB"
         cpu: 1
         disks: "~{disk_size_gb} GB"
@@ -244,7 +244,7 @@ task plot_umap {
     }
 
     runtime {
-        container: "ghcr.io/stjudecloud/python-plotting:branch-scripts-2.0.1"
+        container: "ghcr.io/stjudecloud/python-plotting:2.0.1"
         memory: "4 GB"
         cpu: 1
         disks: "4 GB"

--- a/workflows/methylation/methylation-cohort.wdl
+++ b/workflows/methylation/methylation-cohort.wdl
@@ -124,7 +124,7 @@ task combine_data {
     }
 
     runtime {
-        container: "ghcr.io/stjudecloud/pandas:2.2.1-4"
+        container: "ghcr.io/stjudecloud/pandas:branch-scripts-2.2.1-4"
         memory: "~{memory_gb} GB"
         cpu: 1
         disks: "~{disk_size_gb} GB"
@@ -170,7 +170,7 @@ task filter_probes {
     }
 
     runtime {
-        container: "ghcr.io/stjudecloud/pandas:2.2.1-4"
+        container: "ghcr.io/stjudecloud/pandas:branch-scripts-2.2.1-4"
         memory: "8 GB"
         cpu: 1
         disks: "~{disk_size_gb} GB"
@@ -209,7 +209,7 @@ task generate_umap {
     }
 
     runtime {
-        container: "ghcr.io/stjudecloud/umap:0.5.7-5"
+        container: "ghcr.io/stjudecloud/umap:branch-scripts-0.5.7-5"
         memory: "8 GB"
         cpu: 1
         disks: "~{disk_size_gb} GB"
@@ -244,7 +244,7 @@ task plot_umap {
     }
 
     runtime {
-        container: "ghcr.io/stjudecloud/python-plotting:2.0.1"
+        container: "ghcr.io/stjudecloud/python-plotting:branch-scripts-2.0.1"
         memory: "4 GB"
         cpu: 1
         disks: "4 GB"

--- a/workflows/methylation/methylation-preprocess.wdl
+++ b/workflows/methylation/methylation-preprocess.wdl
@@ -34,7 +34,7 @@ task process_raw_idats {
 
         ln -s ~{idats.left} ~{idats.right} .
 
-        Rscript $(which methylation-preprocess.R) \
+        Rscript /scripts/methylation/methylation-preprocess.R \
             --idat_base ~{idat_base} \
             --out_base ~{out_base} \
             --seed ~{seed}
@@ -53,7 +53,7 @@ task process_raw_idats {
     }
 
     runtime {
-        container: "ghcr.io/stjudecloud/minfi:1.48.0-2"
+        container: "ghcr.io/stjudecloud/minfi:1.48.0-3"
         memory: "8 GB"
         cpu: 1
         disks: "~{disk_size_gb} GB"

--- a/workflows/methylation/methylation-preprocess.wdl
+++ b/workflows/methylation/methylation-preprocess.wdl
@@ -53,7 +53,7 @@ task process_raw_idats {
     }
 
     runtime {
-        container: "ghcr.io/stjudecloud/minfi:branch-scripts-1.48.0-3"
+        container: "ghcr.io/stjudecloud/minfi:1.48.0-3"
         memory: "8 GB"
         cpu: 1
         disks: "~{disk_size_gb} GB"

--- a/workflows/methylation/methylation-preprocess.wdl
+++ b/workflows/methylation/methylation-preprocess.wdl
@@ -53,7 +53,7 @@ task process_raw_idats {
     }
 
     runtime {
-        container: "ghcr.io/stjudecloud/minfi:1.48.0-3"
+        container: "ghcr.io/stjudecloud/minfi:branch-scripts-1.48.0-3"
         memory: "8 GB"
         cpu: 1
         disks: "~{disk_size_gb} GB"

--- a/workflows/qc/quality-check-standard.wdl
+++ b/workflows/qc/quality-check-standard.wdl
@@ -557,7 +557,7 @@ task parse_input {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:2.0.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }

--- a/workflows/qc/quality-check-standard.wdl
+++ b/workflows/qc/quality-check-standard.wdl
@@ -557,7 +557,7 @@ task parse_input {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }

--- a/workflows/qc/quality-check-standard.wdl
+++ b/workflows/qc/quality-check-standard.wdl
@@ -557,7 +557,7 @@ task parse_input {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:2.1.0"
+        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
         maxRetries: 1
     }
 }

--- a/workflows/rnaseq/rnaseq-standard.wdl
+++ b/workflows/rnaseq/rnaseq-standard.wdl
@@ -179,7 +179,7 @@ task parse_input {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:2.0.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }

--- a/workflows/rnaseq/rnaseq-standard.wdl
+++ b/workflows/rnaseq/rnaseq-standard.wdl
@@ -179,7 +179,7 @@ task parse_input {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
+        container: "ghcr.io/stjudecloud/util:2.1.0"
         maxRetries: 1
     }
 }

--- a/workflows/rnaseq/rnaseq-standard.wdl
+++ b/workflows/rnaseq/rnaseq-standard.wdl
@@ -179,7 +179,7 @@ task parse_input {
     runtime {
         memory: "4 GB"
         disks: "10 GB"
-        container: "ghcr.io/stjudecloud/util:2.1.0"
+        container: "ghcr.io/stjudecloud/util:branch-scripts-2.1.0"
         maxRetries: 1
     }
 }


### PR DESCRIPTION
_Describe the problem or feature in addition to a link to the issues._

Fixes #214 

Also adds a new Docker convention that scripts copied from `scripts/` should use the same path within the image (e.g. `scripts/star/sort_star_input.py` should be copied to and called as `/scripts/star/sort_star_input.py`)

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] The code passes all CI tests without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in any relevant CHANGELOGs (when appropriate).
- [x] If you have made any changes to the `scripts/` or `docker/` directories, please ensure any image versions have been incremented accordingly!
- [x] You have updated the README or other documentation to account for these changes (when appropriate).