### PR TITLE
fix: backup extension on mac works now

### DIFF
--- a/developer_scripts/update_container_tags.sh
+++ b/developer_scripts/update_container_tags.sh
@@ -16,9 +16,7 @@ fi
 # freeBSD sed (including the Mac version) requires a space and then an argument to -i
 if [ "$(uname)" == "Darwin" ]
 then
-  inplace_arg='-i ""'
+  find . -not -path '.git' -a -type f -name '*.wdl' | xargs sed -Er -i '' "s,$search_pattern,$replacement,g"
 else
-  inplace_arg='-i'
+  find . -not -path '.git' -a -type f -name '*.wdl' | xargs sed -Er -i'' "s,$search_pattern,$replacement,g"
 fi
-
-find . -not -path '.git' -a -type f -name '*.wdl' | xargs sed -Er $inplace_arg "s,$search_pattern,$replacement,g"


### PR DESCRIPTION
With the previous solution, the bash argument wasn't being interpreted by the Mac `sed` version as a zero-length string. So it was appending the literal `''` suffix and creating backup files. The fix is repetitive, but I can't get anything else to recognize the zero-length string properly.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [ ] The code passes all CI tests without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in any relevant CHANGELOGs (when appropriate).
- [ ] If you have made any changes to the `scripts/` or `docker/` directories, please ensure any image versions have been incremented accordingly!
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).