### PR TITLE
fix: correct struct declaration

### DIFF
--- a/tools/samtools.wdl
+++ b/tools/samtools.wdl
@@ -827,11 +827,11 @@ task bam_to_fastq {
 
     input {
         File bam
-        FlagFilter bitwise_filter = {
-            "include_if_all": "0x0",
-            "exclude_if_any": "0x900",
-            "include_if_any": "0x0",
-            "exclude_if_all": "0x0",
+        FlagFilter bitwise_filter = FlagFilter {
+            include_if_all: "0x0",
+            exclude_if_any: "0x900",
+            include_if_any: "0x0",
+            exclude_if_all: "0x0",
         }
         String prefix = basename(bam, ".bam")
         Boolean paired_end = true


### PR DESCRIPTION
The declaration of the `struct` is incorrect. It worked, because the object could be coerced to a struct type.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] The code passes all CI tests without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in any relevant CHANGELOGs (when appropriate).
- [ ] If you have made any changes to the `scripts/` or `docker/` directories, please ensure any image versions have been incremented accordingly!
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).