### PR TITLE
chore: add trailing commas

### DIFF
--- a/.github/workflows/sprocket-lint.yaml
+++ b/.github/workflows/sprocket-lint.yaml
@@ -14,4 +14,4 @@ jobs:
             exclude-patterns: template
             deny-warnings: true
             deny-notes: true
-            except: TrailingComma,ContainerUri
+            except: ContainerUri

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 fastq==2.0.4
 miniFasta==3.0.3
-miniwdl==1.12.0
+miniwdl==1.13.0
 pysam==0.21.0
 pytest-workflow==2.0.1

--- a/tools/arriba.wdl
+++ b/tools/arriba.wdl
@@ -77,7 +77,7 @@ task arriba {
                 "intronic",
                 "in_vitro",
                 "intragenic_exonic",
-                "internal_tandem_duplication"
+                "internal_tandem_duplication",
             ],
         }
         feature_name: {
@@ -94,7 +94,7 @@ task arriba {
                 "auto",
                 "yes",
                 "no",
-                "reverse"
+                "reverse",
             ],
         }
         mark_duplicates: {

--- a/tools/fq.wdl
+++ b/tools/fq.wdl
@@ -37,7 +37,7 @@ task fqlint {
             choices: [
                 "low",
                 "medium",
-                "high"
+                "high",
             ],
         }
         paired_read_validation_level: {
@@ -45,7 +45,7 @@ task fqlint {
             choices: [
                 "low",
                 "medium",
-                "high"
+                "high",
             ],
         }
         panic: {

--- a/tools/gatk4.wdl
+++ b/tools/gatk4.wdl
@@ -396,7 +396,7 @@ task mark_duplicates_spark {
             choices: [
                 "SUM_OF_BASE_QUALITIES",
                 "TOTAL_MAPPED_REFERENCE_LENGTH",
-                "RANDOM"
+                "RANDOM",
             ],
         }
         read_name_regex: "Regular expression for extracting tile names, x coordinates, and y coordinates from read names. The default works for typical Illumina read names."
@@ -405,7 +405,7 @@ task mark_duplicates_spark {
             choices: [
                 "DontTag",
                 "OpticalOnly",
-                "All"
+                "All",
             ],
         }
         validation_stringency: {
@@ -413,7 +413,7 @@ task mark_duplicates_spark {
             choices: [
                 "STRICT",
                 "LENIENT",
-                "SILENT"
+                "SILENT",
             ],
             tool_default: "STRICT",
         }

--- a/tools/htseq.wdl
+++ b/tools/htseq.wdl
@@ -19,7 +19,7 @@ task count {
             choices: [
                 "yes",
                 "reverse",
-                "no"
+                "no",
             ],
         }
         prefix: "Prefix for the feature counts file. The extension `.feature-counts.txt` will be added."
@@ -37,7 +37,7 @@ task count {
             choices: [
                 "union",
                 "intersection-strict",
-                "intersection-nonempty"
+                "intersection-nonempty",
             ],
         }
         include_custom_header: {

--- a/tools/kraken2.wdl
+++ b/tools/kraken2.wdl
@@ -70,7 +70,7 @@ task download_library {
                 "nt",
                 "nr",
                 "UniVec",
-                "UniVec_Core"
+                "UniVec_Core",
             ],
         }
         protein: "Construct a protein database?"

--- a/tools/picard.wdl
+++ b/tools/picard.wdl
@@ -26,7 +26,7 @@ task mark_duplicates {
             choices: [
                 "SUM_OF_BASE_QUALITIES",
                 "TOTAL_MAPPED_REFERENCE_LENGTH",
-                "RANDOM"
+                "RANDOM",
             ],
         }
         read_name_regex: "Regular expression for extracting tile names, x coordinates, and y coordinates from read names. The default works for typical Illumina read names."
@@ -35,7 +35,7 @@ task mark_duplicates {
             choices: [
                 "DontTag",
                 "OpticalOnly",
-                "All"
+                "All",
             ],
         }
         validation_stringency: {
@@ -43,7 +43,7 @@ task mark_duplicates {
             choices: [
                 "STRICT",
                 "LENIENT",
-                "SILENT"
+                "SILENT",
             ],
             tool_default: "STRICT",
         }
@@ -150,7 +150,7 @@ task validate_bam {
             choices: [
                 "STRICT",
                 "LENIENT",
-                "SILENT"
+                "SILENT",
             ],
             tool_default: "STRICT",
         }
@@ -270,7 +270,7 @@ task sort {
             choices: [
                 "queryname",
                 "coordinate",
-                "duplicate"
+                "duplicate",
             ],
             group: "Common",
         }
@@ -280,7 +280,7 @@ task sort {
             choices: [
                 "STRICT",
                 "LENIENT",
-                "SILENT"
+                "SILENT",
             ],
             tool_default: "STRICT",
         }
@@ -355,7 +355,7 @@ task merge_sam_files {
                 "unsorted",
                 "queryname",
                 "coordinate",
-                "duplicate"
+                "duplicate",
             ],
             group: "Common",
         }
@@ -364,7 +364,7 @@ task merge_sam_files {
             choices: [
                 "STRICT",
                 "LENIENT",
-                "SILENT"
+                "SILENT",
             ],
             tool_default: "STRICT",
         }
@@ -441,7 +441,7 @@ task clean_sam {
             choices: [
                 "STRICT",
                 "LENIENT",
-                "SILENT"
+                "SILENT",
             ],
             tool_default: "STRICT",
         }
@@ -511,7 +511,7 @@ task collect_wgs_metrics {
             choices: [
                 "STRICT",
                 "LENIENT",
-                "SILENT"
+                "SILENT",
             ],
             tool_default: "STRICT",
         }
@@ -574,7 +574,7 @@ task collect_alignment_summary_metrics {
             choices: [
                 "STRICT",
                 "LENIENT",
-                "SILENT"
+                "SILENT",
             ],
             tool_default: "STRICT",
         }
@@ -641,7 +641,7 @@ task collect_gc_bias_metrics {
             choices: [
                 "STRICT",
                 "LENIENT",
-                "SILENT"
+                "SILENT",
             ],
             tool_default: "STRICT",
         }
@@ -707,7 +707,7 @@ task collect_insert_size_metrics {
             choices: [
                 "STRICT",
                 "LENIENT",
-                "SILENT"
+                "SILENT",
             ],
             tool_default: "STRICT",
         }
@@ -766,7 +766,7 @@ task quality_score_distribution {
             choices: [
                 "STRICT",
                 "LENIENT",
-                "SILENT"
+                "SILENT",
             ],
             tool_default: "STRICT",
         }
@@ -931,7 +931,7 @@ task scatter_interval_list {
             choices: [
                 "BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW",
                 "INTERVAL_SUBDIVISION",
-                "BALANCING_WITHOUT_INTERVAL_SUBDIVISION"
+                "BALANCING_WITHOUT_INTERVAL_SUBDIVISION",
             ],
         }
         unique: "Should the output interval lists contain unique intervals? Implies sort=true. Merges overlapping or adjacent intervals."

--- a/tools/samtools.wdl
+++ b/tools/samtools.wdl
@@ -983,7 +983,7 @@ task fixmate {
             description: "File format extension to use for output file.",
             choices: [
                 ".bam",
-                ".cram"
+                ".cram",
             ],
             group: "Common",
         }
@@ -1191,7 +1191,7 @@ task markdup {
                 "xty",
                 "ytx",
                 "xy",
-                "yx"
+                "yx",
             ],
         }
         create_bam: "Create a new BAM with duplicate reads marked? If `false`, then only a markdup report will be generated."

--- a/tools/util.wdl
+++ b/tools/util.wdl
@@ -339,7 +339,7 @@ task make_coverage_regions_bed {
                 "UTR",
                 "start_codon",
                 "stop_codon",
-                "Selenocysteine"
+                "Selenocysteine",
             ],
         }
         outfile_name: "Name of the output BED file"

--- a/workflows/dnaseq/dnaseq-core.wdl
+++ b/workflows/dnaseq/dnaseq-core.wdl
@@ -31,7 +31,7 @@ workflow dnaseq_core_experimental {
             description: "BWA aligner to use",
             choices: [
                 "mem",
-                "aln"
+                "aln",
             ],
         }
         use_all_cores: "Use all cores? Recommended for cloud environments."

--- a/workflows/dnaseq/dnaseq-standard-fastq.wdl
+++ b/workflows/dnaseq/dnaseq-standard-fastq.wdl
@@ -35,7 +35,7 @@ workflow dnaseq_standard_fastq_experimental {
             description: "BWA aligner to use",
             choices: [
                 "mem",
-                "aln"
+                "aln",
             ],
         }
         validate_input: "Ensure input FASTQs ares well-formed before beginning harmonization?"
@@ -132,7 +132,7 @@ task parse_input {
             description: "BWA aligner to use",
             choices: [
                 "mem",
-                "aln"
+                "aln",
             ],
         }
     }

--- a/workflows/dnaseq/dnaseq-standard.wdl
+++ b/workflows/dnaseq/dnaseq-standard.wdl
@@ -29,7 +29,7 @@ workflow dnaseq_standard_experimental {
             description: "BWA aligner to use",
             choices: [
                 "mem",
-                "aln"
+                "aln",
             ],
         }
         validate_input: "Ensure input BAM is well-formed before beginning harmonization?"
@@ -110,7 +110,7 @@ task parse_input {
             description: "BWA aligner to use",
             choices: [
                 "mem",
-                "aln"
+                "aln",
             ],
         }
     }

--- a/workflows/general/alignment-post.wdl
+++ b/workflows/general/alignment-post.wdl
@@ -27,7 +27,7 @@ workflow alignment_post {
             choices: [
                 "bwa aln",
                 "bwa mem",
-                "star"
+                "star",
             ],
         }
         cleanse_xenograft: "If true, use XenoCP to unmap reads from contaminant genome"

--- a/workflows/reference/qc-reference.wdl
+++ b/workflows/reference/qc-reference.wdl
@@ -38,7 +38,7 @@ workflow qc_reference {
                 "protozoa",
                 "nt",
                 "UniVec",
-                "UniVec_Core"
+                "UniVec_Core",
             ],
         }
         coverage_feature_types: {
@@ -52,7 +52,7 @@ workflow qc_reference {
                 "UTR",
                 "start_codon",
                 "stop_codon",
-                "Selenocysteine"
+                "Selenocysteine",
             ],
         }
         protein: "Construct a protein database?"

--- a/workflows/rnaseq/rnaseq-core.wdl
+++ b/workflows/rnaseq/rnaseq-core.wdl
@@ -54,7 +54,7 @@ workflow rnaseq_core {
             choices: [
                 "bwa aln",
                 "bwa mem",
-                "star"
+                "star",
             ],
         }
         strandedness: {
@@ -63,7 +63,7 @@ workflow rnaseq_core {
                 "",
                 "Stranded-Reverse",
                 "Stranded-Forward",
-                "Unstranded"
+                "Unstranded",
             ],
         }
         mark_duplicates: "Add SAM flag to computationally determined duplicate reads?"

--- a/workflows/rnaseq/rnaseq-standard-fastq.wdl
+++ b/workflows/rnaseq/rnaseq-standard-fastq.wdl
@@ -76,7 +76,7 @@ workflow rnaseq_standard_fastq {
             choices: [
                 "bwa aln",
                 "bwa mem",
-                "star"
+                "star",
             ],
         }
         strandedness: {
@@ -85,7 +85,7 @@ workflow rnaseq_standard_fastq {
                 "",
                 "Stranded-Reverse",
                 "Stranded-Forward",
-                "Unstranded"
+                "Unstranded",
             ],
         }
         mark_duplicates: "Add SAM flag to computationally determined duplicate reads?"

--- a/workflows/rnaseq/rnaseq-standard.wdl
+++ b/workflows/rnaseq/rnaseq-standard.wdl
@@ -35,7 +35,7 @@ workflow rnaseq_standard {
             choices: [
                 "bwa aln",
                 "bwa mem",
-                "star"
+                "star",
             ],
         }
         strandedness: {
@@ -44,7 +44,7 @@ workflow rnaseq_standard {
                 "",
                 "Stranded-Reverse",
                 "Stranded-Forward",
-                "Unstranded"
+                "Unstranded",
             ],
         }
         mark_duplicates: "Add SAM flag to computationally determined duplicate reads?"
@@ -142,7 +142,7 @@ task parse_input {
                 "",
                 "Stranded-Reverse",
                 "Stranded-Forward",
-                "Unstranded"
+                "Unstranded",
             ],
         }
         cleanse_xenograft: "Use XenoCP to unmap reads from contaminant genome?"


### PR DESCRIPTION
Enabling the `TrailingCommas` lint now that `miniwdl` supports the syntax. Updating the WDL files to use trailing commas.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] The code passes all CI tests without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in any relevant CHANGELOGs (when appropriate).
- [x] If you have made any changes to the `scripts/` or `docker/` directories, please ensure any image versions have been incremented accordingly!
- [x] You have updated the README or other documentation to account for these changes (when appropriate).