### PR TITLE
fix: bad string concat

### DIFF
--- a/data_structures/read_group.wdl
+++ b/data_structures/read_group.wdl
@@ -396,22 +396,20 @@ task inner_read_group_to_string {
             echo -n "@RG~{delimiter}" > out.txt
         fi
         {
-            echo -n "~{"ID:~{read_group.ID}"}"  # required field. All others optional
-            # if any individual placeholder of an interpolated String evaluates to None
-            # the entire parent String will evaluate to the empty String.
-            echo -n "~{"~{delimiter}BC:~{read_group.BC}"}"
-            echo -n "~{"~{delimiter}CN:~{read_group.CN}"}"
-            echo -n "~{"~{delimiter}DS:~{read_group.DS}"}"
-            echo -n "~{"~{delimiter}DT:~{read_group.DT}"}"
-            echo -n "~{"~{delimiter}FO:~{read_group.FO}"}"
-            echo -n "~{"~{delimiter}KS:~{read_group.KS}"}"
-            echo -n "~{"~{delimiter}LB:~{read_group.LB}"}"
-            echo -n "~{"~{delimiter}PG:~{read_group.PG}"}"
-            echo -n "~{"~{delimiter}PI:~{read_group.PI}"}"
-            echo -n "~{"~{delimiter}PL:~{read_group.PL}"}"
-            echo -n "~{"~{delimiter}PM:~{read_group.PM}"}"
-            echo -n "~{"~{delimiter}PU:~{read_group.PU}"}"
-            echo "~{"~{delimiter}SM:~{read_group.SM}"}"
+            echo -n "~{"ID:" + read_group.ID}"  # required field. All others optional
+            echo -n "~{delimiter + "BC:" + read_group.BC}"
+            echo -n "~{delimiter + "CN:" + read_group.CN}"
+            echo -n "~{delimiter + "DS:" + read_group.DS}"
+            echo -n "~{delimiter + "DT:" + read_group.DT}"
+            echo -n "~{delimiter + "FO:" + read_group.FO}"
+            echo -n "~{delimiter + "KS:" + read_group.KS}"
+            echo -n "~{delimiter + "LB:" + read_group.LB}"
+            echo -n "~{delimiter + "PG:" + read_group.PG}"
+            echo -n "~{delimiter + "PI:" + read_group.PI}"
+            echo -n "~{delimiter + "PL:" + read_group.PL}"
+            echo -n "~{delimiter + "PM:" + read_group.PM}"
+            echo -n "~{delimiter + "PU:" + read_group.PU}"
+            echo "~{delimiter + "SM:" + read_group.SM}"
         } >> out.txt
     >>>
 


### PR DESCRIPTION
_Describe the problem or feature in addition to a link to the issues._

not sure where this confusion came from, but I wrote the `ReadGroup`->`String` task with a bad understanding of the WDL spec and how optional strings were handled.

Before submitting this PR, please make sure:

- [ ] You have added a few sentences describing the PR here.
- [ ] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [ ] The code passes all CI tests without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in any relevant CHANGELOGs (when appropriate).
- [ ] If you have made any changes to the `scripts/` or `docker/` directories, please ensure any image versions have been incremented accordingly!
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).