### PR TITLE
fix: methylation samplenames

### DIFF
--- a/docker/minfi/package.json
+++ b/docker/minfi/package.json
@@ -1,5 +1,5 @@
 {
     "name": "minfi",
     "version": "1.48.0",
-    "revision": "5"
+    "revision": "6"
 }

--- a/scripts/CHANGELOG.md
+++ b/scripts/CHANGELOG.md
@@ -13,6 +13,8 @@ Any change to the `scripts/` directory should be accompanied by version increase
 ### Changed
 
 - Replaced `black` and `pyright` with `ruff` [#255](https://github.com/stjudecloud/workflows/pull/255).
+- Beta value matrix now retains sample names as column names [#259](https://github.com/stjudecloud/workflows/pull/259)
+
 
 ## 2025 July
 

--- a/scripts/methylation/methylation-preprocess.R
+++ b/scripts/methylation/methylation-preprocess.R
@@ -99,7 +99,8 @@ write.csv(
 r_set <- ratioConvert(gr_set_swan_norm)
 gr_set <- mapToGenome(r_set)
 beta_swan_norm <- getBeta(gr_set)
-beta_swan_norm <- beta_swan_norm[order(rownames(beta_swan_norm)), , drop = FALSE]
+beta_swan_norm <-
+  beta_swan_norm[order(rownames(beta_swan_norm)), , drop = FALSE]
 write.csv(
   beta_swan_norm,
   paste0(args$out_base, ".beta_swan_norm_unfiltered.genomic.csv")

--- a/scripts/methylation/methylation-preprocess.R
+++ b/scripts/methylation/methylation-preprocess.R
@@ -99,7 +99,7 @@ write.csv(
 r_set <- ratioConvert(gr_set_swan_norm)
 gr_set <- mapToGenome(r_set)
 beta_swan_norm <- getBeta(gr_set)
-colnames(beta_swan_norm) <- colnames(cn)
+#colnames(beta_swan_norm) <- colnames(cn)
 write.csv(
   beta_swan_norm[order(rownames(beta_swan_norm)), ],
   paste0(args$out_base, ".beta_swan_norm_unfiltered.genomic.csv")

--- a/scripts/methylation/methylation-preprocess.R
+++ b/scripts/methylation/methylation-preprocess.R
@@ -99,8 +99,8 @@ write.csv(
 r_set <- ratioConvert(gr_set_swan_norm)
 gr_set <- mapToGenome(r_set)
 beta_swan_norm <- getBeta(gr_set)
-#colnames(beta_swan_norm) <- colnames(cn)
+beta_swan_norm <- beta_swan_norm[order(rownames(beta_swan_norm)), , drop = FALSE]
 write.csv(
-  beta_swan_norm[order(rownames(beta_swan_norm)), ],
+  beta_swan_norm,
   paste0(args$out_base, ".beta_swan_norm_unfiltered.genomic.csv")
 )

--- a/workflows/methylation/CHANGELOG.md
+++ b/workflows/methylation/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
  
+## 2025 August
+
+### Changed
+
+- Beta value matrix now retains sample names as column names [#259](https://github.com/stjudecloud/workflows/pull/259)
+
 ## 2025 July
 
 ### Changed

--- a/workflows/methylation/methylation-preprocess.wdl
+++ b/workflows/methylation/methylation-preprocess.wdl
@@ -53,7 +53,7 @@ task process_raw_idats {
     }
 
     runtime {
-        container: "ghcr.io/stjudecloud/minfi:1.48.0-5"
+        container: "ghcr.io/stjudecloud/minfi:1.48.0-6"
         memory: "8 GB"
         cpu: 1
         disks: "~{disk_size_gb} GB"


### PR DESCRIPTION
When a single-column dataframe is manipulated in R, R silently converts it to a vector. This PR adds `drop = FALSE` to the dataframe manipulation to prevent the conversion.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] The code passes all CI tests without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [x] You have added an entry in any relevant CHANGELOGs (when appropriate).
- [x] If you have made any changes to the `scripts/` or `docker/` directories, please ensure any image versions have been incremented accordingly!
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).