### PR TITLE
fix: pin Ubuntu image dependency

### DIFF
--- a/docker/util/Dockerfile
+++ b/docker/util/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:noble-20250925
 
 RUN apt-get update \
     && apt-get upgrade -y \


### PR DESCRIPTION
Pin the Ubuntu base image to a specific build, rather than only a major+minor pair. Ubuntu overwrites the major+minor pair when a patch is released. This switches to using the data stamped release in place of a major+minor pair (24.04 == "noble").

Before submitting this PR, please make sure:

- [ ] You have added a few sentences describing the PR here.
- [ ] The code passes all CI tests without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in any relevant CHANGELOGs (when appropriate).
- [ ] If you have made any changes to the `scripts/` or `docker/` directories, please ensure any image versions have been incremented accordingly!
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).