### PR TITLE
ci: Install Sprocket from binary

### DIFF
--- a/.github/workflows/sprocket-test.yaml
+++ b/.github/workflows/sprocket-test.yaml
@@ -26,11 +26,11 @@ jobs:
     - uses: actions/checkout@v4
       with:
         lfs: true
-    - name: Update Rust
-      run: rustup update stable && rustup default stable
-    - name: Build Sprocket
+    - name: Install Sprocket
       run: |
-        cargo install sprocket --locked
+        SPROCKET_URL=$(curl -sSL https://api.github.com/repos/stjude-rust-labs/sprocket/releases/latest \
+          | jq -r '.assets[] | select(.name | test("x86_64-unknown-linux-gnu.tar.gz")) | .browser_download_url')
+        curl -sSL "$SPROCKET_URL" | tar -xz -C /usr/local/bin sprocket
     - name: Update containers
       run: |
         ./developer_scripts/update_container_tags.sh ${GITHUB_REF##*/}


### PR DESCRIPTION
Install Sprocket binary, rather than from source. This grabs the latest release, so it won't have features on main, but unreleased.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [ ] The code passes all CI tests without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in any relevant CHANGELOGs (when appropriate).
- [ ] If you have made any changes to the `scripts/` or `docker/` directories, please ensure any image versions have been incremented accordingly!
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).