### PR TITLE
chore: exceptions for tasks with no outputs

### DIFF
--- a/data_structures/flag_filter.wdl
+++ b/data_structures/flag_filter.wdl
@@ -67,6 +67,7 @@ struct FlagFilter {
     String exclude_if_all  # samtools -G
 }
 
+#@ except: EmptyOutputs
 task validate_string_is_12bit_int {
     meta {
         description: "Validates that a string is a octal, decimal, or hexadecimal number and less than 2^12."

--- a/data_structures/read_group.wdl
+++ b/data_structures/read_group.wdl
@@ -143,6 +143,7 @@ task get_read_groups {
     }
 }
 
+#@ except: EmptyOutputs
 task validate_read_group {
     meta {
         description: "Validate a `ReadGroup` struct's fields are defined and well-formed"

--- a/tools/fq.wdl
+++ b/tools/fq.wdl
@@ -1,6 +1,7 @@
 ## [Homepage](https://github.com/stjude-rust-labs/fq)
 version 1.1
 
+#@ except: EmptyOutputs
 task fqlint {
     meta {
         description: "Performs quality control on the input FASTQs to ensure proper formatting"

--- a/tools/samtools.wdl
+++ b/tools/samtools.wdl
@@ -3,6 +3,7 @@ version 1.1
 
 import "../data_structures/flag_filter.wdl"
 
+#@ except: EmptyOutputs
 task quickcheck {
     meta {
         description: "Runs Samtools quickcheck on the input BAM file."

--- a/tools/util.wdl
+++ b/tools/util.wdl
@@ -132,6 +132,7 @@ task calc_feature_lengths {
     }
 }
 
+#@ except: EmptyOutputs
 task compression_integrity {
     meta {
         description: "Checks the compression integrity of a bgzipped file"
@@ -358,6 +359,7 @@ task global_phred_scores {
     }
 }
 
+#@ except: EmptyOutputs
 task check_fastq_and_rg_concordance {
     meta {
         description: "Validates FASTQs and read group records are concordant"

--- a/workflows/dnaseq/dnaseq-standard.wdl
+++ b/workflows/dnaseq/dnaseq-standard.wdl
@@ -133,6 +133,7 @@ workflow dnaseq_standard_experimental {
     }
 }
 
+#@ except: EmptyOutputs
 task parse_input {
     meta {
         description: "Parses and validates the `dnaseq_standard` workflow's provided inputs"

--- a/workflows/rnaseq/rnaseq-standard.wdl
+++ b/workflows/rnaseq/rnaseq-standard.wdl
@@ -141,6 +141,7 @@ workflow rnaseq_standard {
     }
 }
 
+#@ except: EmptyOutputs
 task parse_input {
     meta {
         description: "Parses and validates the `rnaseq_standard[_fastq]` workflows' provided inputs"


### PR DESCRIPTION
Several of our WDL tasks have no outputs (by design). The latest version of Sprocket flags these with a lint. This adds the appropriate `#@ except` statements.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] The code passes all CI tests without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in any relevant CHANGELOGs (when appropriate).
- [ ] If you have made any changes to the `scripts/` or `docker/` directories, please ensure any image versions have been incremented accordingly!
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).