### PR TITLE
use non-empty array qualifiers

### DIFF
--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Change Log
 
 All notable changes to this project will be documented in this file.
- 
+
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
+
+## 2026 August
+
+### Changed
+
+- Enforced non-empty qualifiers on `Array[*]` types that cannot be empty [#328](https://github.com/stjudecloud/workflows/pull/328)
 
 ## 2026 February
 
@@ -56,8 +62,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fixed
 
 - Upstream bug in Sprocket patched locally [#251](https://github.com/stjudecloud/workflows/pull/251)
-    - Upstream bug [here](https://github.com/stjude-rust-labs/wdl/issues/574)
-    - Local fix was moving a private declaration in `samtools.merge_sam_files` to the command body 
+  - Upstream bug [here](https://github.com/stjude-rust-labs/wdl/issues/574)
+  - Local fix was moving a private declaration in `samtools.merge_sam_files` to the command body
 
 ### Removed
 
@@ -77,18 +83,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - "validation tasks" no longer have output sections [#240](https://github.com/stjudecloud/workflows/pull/240).
 - "lightweight tasks" now rely on the WDL spec's default `memory` and `disks` values instead of manually specifying something arbitrary [#240](https://github.com/stjudecloud/workflows/pull/240).
 - `star.alignment` now specifies `read_one_fastqs_gz` and `read_groups` must be non-empty [#235](https://github.com/stjudecloud/workflows/pull/235).
-    - immediately reverted in [#240](https://github.com/stjudecloud/workflows/pull/240).
+  - immediately reverted in [#240](https://github.com/stjudecloud/workflows/pull/240).
 - `star.alignment` input `read_two_fastqs_gz` is now an `Array[File]+?`, allowing it to be omitted entirely [#235](https://github.com/stjudecloud/workflows/pull/235).
-    - immediately reverted in [#240](https://github.com/stjudecloud/workflows/pull/240).
+  - immediately reverted in [#240](https://github.com/stjudecloud/workflows/pull/240).
 
 ### Removed
 
 - removed interleaved FASTQ option from `samtools.bam_to_fastq` [#244](https://github.com/stjudecloud/workflows/pull/244).
 - removed all uses of non-empty (`+`) array qualifier [#240](https://github.com/stjudecloud/workflows/pull/240).
 - `star.alignment` no longer sorts inputs prior to passing to STAR [#235](https://github.com/stjudecloud/workflows/pull/235).
-    - This means you have to ensure the FASTQs and RG records are concordant in your inputs!
+  - This means you have to ensure the FASTQs and RG records are concordant in your inputs!
 - `util.get_read_groups` has been removed [#235](https://github.com/stjudecloud/workflows/pull/235).
-    - see `data_structures/read_group.wdl` for an alternative.
+  - see `data_structures/read_group.wdl` for an alternative.
 
 ## 2025 May
 
@@ -106,7 +112,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - `ngsderive.encoding` removed the `String inferred_encoding` output [#216](https://github.com/stjudecloud/workflows/pull/216).
 - Improved the REGEX used to calculate a prefix for FASTQ input files in various tools [#220](https://github.com/stjudecloud/workflows/pull/220).
- 
+
 ## 2025 January
 
 ### Changed

--- a/tools/kraken2.wdl
+++ b/tools/kraken2.wdl
@@ -158,7 +158,7 @@ task create_library_from_fastas {
     }
 
     input {
-        Array[File] fastas_gz
+        Array[File]+ fastas_gz
         Boolean protein = false
         Int modify_disk_size_gb = 0
     }
@@ -241,7 +241,7 @@ task build_db {
     }
 
     input {
-        Array[File] tarballs
+        Array[File]+ tarballs
         String db_name = "kraken2_db"
         Boolean protein = false
         Boolean use_all_cores = false

--- a/tools/multiqc.wdl
+++ b/tools/multiqc.wdl
@@ -22,7 +22,7 @@ task multiqc {
     }
 
     input {
-        Array[File] files
+        Array[File]+ files
         String report_name
         File? config
         Int modify_disk_size_gb = 0

--- a/tools/ngsderive.wdl
+++ b/tools/ngsderive.wdl
@@ -229,7 +229,7 @@ task encoding {
     }
 
     input {
-        Array[File] ngs_files
+        Array[File]+ ngs_files
         String outfile_name
         Int num_reads = 1000000
         Int modify_disk_size_gb = 0

--- a/tools/picard.wdl
+++ b/tools/picard.wdl
@@ -375,7 +375,7 @@ task merge_sam_files {
     }
 
     input {
-        Array[File] bams
+        Array[File]+ bams
         String prefix
         String sort_order = "coordinate"
         String validation_stringency = "SILENT"
@@ -847,8 +847,8 @@ task merge_vcfs {
     }
 
     input {
-        Array[File] vcfs
-        Array[File] vcfs_indexes
+        Array[File]+ vcfs
+        Array[File]+ vcfs_indexes
         String output_vcf_name
         Int modify_disk_size_gb = 0
     }

--- a/tools/sambamba.wdl
+++ b/tools/sambamba.wdl
@@ -81,7 +81,7 @@ task merge {
     }
 
     input {
-        Array[File] bams
+        Array[File]+ bams
         String prefix
         Boolean use_all_cores = false
         Int ncpu = 2

--- a/tools/samtools.wdl
+++ b/tools/samtools.wdl
@@ -549,7 +549,7 @@ task merge {
     }
 
     input {
-        Array[File] bams
+        Array[File]+ bams
         String prefix
         File? new_header
         # String region = ""

--- a/tools/star.wdl
+++ b/tools/star.wdl
@@ -553,8 +553,8 @@ task alignment {
 
     input {
         File star_db_tar_gz
-        Array[File] read_one_fastqs_gz
-        Array[String] read_groups
+        Array[File]+ read_one_fastqs_gz
+        Array[String]+ read_groups
         Array[File]? read_two_fastqs_gz
         Array[Int] out_sj_filter_intron_max_vs_read_n = [
             50000,

--- a/tools/test/multiqc.yaml
+++ b/tools/test/multiqc.yaml
@@ -9,7 +9,6 @@ multiqc:
     inputs:
       files:
         - ["README.md", "tarball.tar.gz"]
-        - []
       report_name:
         - will_fail
     assertions:

--- a/tools/test/ngsderive.yaml
+++ b/tools/test/ngsderive.yaml
@@ -4,13 +4,10 @@ strandedness:
       $files:
         bam:
           - bams/test.bwa_aln_pe.chrY_chrM.bam
-          - bams/Aligned.sortedByCoord.chr9_chr22.bam
         bam_index:
           - bams/test.bwa_aln_pe.chrY_chrM.bam.bai
-          - bams/Aligned.sortedByCoord.chr9_chr22.bam.bai
         gene_model:
           - reference/gencode.v31.chrY_chrM.gtf.gz
-          - reference/gencode.v31.chr9_chr22.gtf.gz
       split_by_rg:
         - false
       min_reads_per_gene:
@@ -26,6 +23,30 @@ strandedness:
       outputs:
         strandedness_string:
           - StrEquals: Unstranded
+  - name: inconclusive
+    inputs:
+      $files:
+        bam:
+          - bams/Aligned.sortedByCoord.chr9_chr22.bam
+        bam_index:
+          - bams/Aligned.sortedByCoord.chr9_chr22.bam.bai
+        gene_model:
+          - reference/gencode.v31.chr9_chr22.gtf.gz
+      split_by_rg:
+        - false
+      min_reads_per_gene:
+        - 10
+        - 5
+      num_genes:
+        - 1000
+        - 500
+      min_mapq:
+        - 30
+        - 0
+    assertions:
+      outputs:
+        strandedness_string:
+          - StrEquals: Inconclusive
   - name: split_by_rg
     inputs:
       $files:

--- a/tools/util.wdl
+++ b/tools/util.wdl
@@ -389,8 +389,8 @@ task check_fastq_and_rg_concordance {
     }
 
     input {
-        Array[String] read_one_names
-        Array[String] read_groups
+        Array[String]+ read_one_names
+        Array[String]+ read_groups
         Array[String]? read_two_names
     }
 

--- a/workflows/chipseq/CHANGELOG.md
+++ b/workflows/chipseq/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Change Log
 
 All notable changes to this project will be documented in this file.
- 
+
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
- 
+
+## 2026 August
+
+### Changed
+
+- Enforced non-empty qualifiers on `Array[*]` types that cannot be empty [#328](https://github.com/stjudecloud/workflows/pull/328)
+
 ## 2025 July
 
 ### Added

--- a/workflows/chipseq/chipseq-standard.wdl
+++ b/workflows/chipseq/chipseq-standard.wdl
@@ -45,7 +45,7 @@ workflow chipseq_standard_experimental {
 
     input {
         File bam
-        Array[File] bowtie_indexes
+        Array[File]+ bowtie_indexes
         File? excludelist
         String prefix = basename(bam, ".bam")
         Boolean enable_read_trimming = false

--- a/workflows/dnaseq/CHANGELOG.md
+++ b/workflows/dnaseq/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Change Log
 
 All notable changes to this project will be documented in this file.
- 
+
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
- 
+
+## 2026 August
+
+### Changed
+
+- Enforced non-empty qualifiers on `Array[*]` types that cannot be empty [#328](https://github.com/stjudecloud/workflows/pull/328)
+
 ## 2025 July
 
 ### Added

--- a/workflows/dnaseq/dnaseq-core.wdl
+++ b/workflows/dnaseq/dnaseq-core.wdl
@@ -45,9 +45,9 @@ workflow dnaseq_core_experimental {
 
     input {
         File bwa_db
-        Array[File] read_one_fastqs_gz
+        Array[File]+ read_one_fastqs_gz
         Array[File] read_two_fastqs_gz
-        Array[String] read_groups
+        Array[String]+ read_groups
         String prefix
         String aligner
         Boolean enable_read_trimming

--- a/workflows/dnaseq/dnaseq-standard-fastq.wdl
+++ b/workflows/dnaseq/dnaseq-standard-fastq.wdl
@@ -50,9 +50,9 @@ workflow dnaseq_standard_fastq_experimental {
 
     input {
         File bwa_db
-        Array[File] read_one_fastqs_gz
+        Array[File]+ read_one_fastqs_gz
         Array[File] read_two_fastqs_gz
-        Array[ReadGroup] read_groups
+        Array[ReadGroup]+ read_groups
         String prefix = sub(basename(read_one_fastqs_gz[0]), "(([_.][rR](?:ead)?[12])((?:[_.-][^_.-]*?)*?))?\\.(fastq|fq)(\\.gz)?$",
             ""  # Once replacing with capturing groups is supported, replace with group 3
         )

--- a/workflows/general/CHANGELOG.md
+++ b/workflows/general/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Change Log
 
 All notable changes to this project will be documented in this file.
- 
+
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
- 
+
+## 2026 August
+
+### Changed
+
+- Enforced non-empty qualifiers on `Array[*]` types that cannot be empty [#328](https://github.com/stjudecloud/workflows/pull/328)
+
 ## 2025 July
 
 ### Fixed

--- a/workflows/general/samtools-merge.wdl
+++ b/workflows/general/samtools-merge.wdl
@@ -22,7 +22,7 @@ workflow samtools_merge {
     }
 
     input {
-        Array[File] bams
+        Array[File]+ bams
         String prefix
         Boolean use_all_cores = false
         Int max_length = 100

--- a/workflows/methylation/CHANGELOG.md
+++ b/workflows/methylation/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Change Log
 
 All notable changes to this project will be documented in this file.
- 
+
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
+
+## 2026 August
+
+### Changed
+
+- Enforced non-empty qualifiers on `Array[*]` types that cannot be empty [#328](https://github.com/stjudecloud/workflows/pull/328)
 
 ## 2026 February
 
@@ -38,9 +44,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Removed
 
 - removed all uses of non-empty (`+`) array qualifier [#240](https://github.com/stjudecloud/workflows/pull/240).
- 
+
 ## 2025 May
 
 ### Changed
 
- * Allow nested inputs [#229](https://github.com/stjudecloud/workflows/pull/229)
+- Allow nested inputs [#229](https://github.com/stjudecloud/workflows/pull/229)

--- a/workflows/methylation/methylation-cohort.wdl
+++ b/workflows/methylation/methylation-cohort.wdl
@@ -26,7 +26,7 @@ workflow methylation_cohort {
     }
 
     input {
-        Array[File] unfiltered_normalized_beta
+        Array[File]+ unfiltered_normalized_beta
         File? sex_probe_list
         File? additional_probes_to_exclude
         Array[File] p_values = []
@@ -166,7 +166,7 @@ task combine_data {
     }
 
     input {
-        Array[File] files_to_combine
+        Array[File]+ files_to_combine
         String combined_file_name = "combined.csv"
         Boolean simple_merge = false
         Int modify_memory_gb = 0

--- a/workflows/methylation/methylation-standard.wdl
+++ b/workflows/methylation/methylation-standard.wdl
@@ -31,8 +31,8 @@ workflow methylation {
     }
 
     input {
-        Array[File] green_idats
-        Array[File] red_idats
+        Array[File]+ green_idats
+        Array[File]+ red_idats
         File? additional_probes_to_exclude
     }
 
@@ -162,7 +162,7 @@ task concat_and_uniq {
     }
 
     input {
-        Array[File] files_to_combine
+        Array[File]+ files_to_combine
         String output_file_name = "unique_lines.txt"
     }
 

--- a/workflows/rnaseq/CHANGELOG.md
+++ b/workflows/rnaseq/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Change Log
 
 All notable changes to this project will be documented in this file.
- 
+
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
+
+## 2026 August
+
+### Changed
+
+- Enforced non-empty qualifiers on `Array[*]` types that cannot be empty [#328](https://github.com/stjudecloud/workflows/pull/328)
 
 ## 2026 January
 
@@ -20,7 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fixed
 
 - FASTQ entrypoint now specifies that FASTQ and read group record inputs must be non-empty [#235](https://github.com/stjudecloud/workflows/pull/235).
-    - immediately reverted in [#240](https://github.com/stjudecloud/workflows/pull/240).
+  - immediately reverted in [#240](https://github.com/stjudecloud/workflows/pull/240).
 
 ### Changed
 
@@ -39,7 +45,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 - Added a default `prefix` calculation for `rnaseq-standard-fastq` and `rnaseq-core` [#220](https://github.com/stjudecloud/workflows/pull/220).
- 
+
 ## 2025 January
 
 ### Changed

--- a/workflows/rnaseq/rnaseq-core.wdl
+++ b/workflows/rnaseq/rnaseq-core.wdl
@@ -129,9 +129,9 @@ workflow rnaseq_core {
     input {
         File gtf
         File star_db
-        Array[File] read_one_fastqs_gz
+        Array[File]+ read_one_fastqs_gz
         Array[File] read_two_fastqs_gz
-        Array[String] read_groups
+        Array[String]+ read_groups
         String strandedness
         Boolean enable_read_trimming
         Boolean mark_duplicates

--- a/workflows/rnaseq/rnaseq-standard-fastq.wdl
+++ b/workflows/rnaseq/rnaseq-standard-fastq.wdl
@@ -69,9 +69,9 @@ workflow rnaseq_standard_fastq {
     input {
         File gtf
         File star_db
-        Array[File] read_one_fastqs_gz
+        Array[File]+ read_one_fastqs_gz
         Array[File] read_two_fastqs_gz
-        Array[ReadGroup] read_groups
+        Array[ReadGroup]+ read_groups
         File? contaminant_db
         String prefix = sub(basename(read_one_fastqs_gz[0]), "(([_.][rR](?:ead)?[12])((?:[_.-][^_.-]*?)*?))?\\.(fastq|fq)(\\.gz)?$",
             ""  # Once replacing with capturing groups is supported, replace with group 3


### PR DESCRIPTION
We attempted and reverted using non-empty qualifies on arrays in an earlier PR (#240) due to friction caused by Sprocket analysis and odd type coercion. That was solved a long time ago and now that friction is gone. It was trivial to make this type update, which was a very pleasant surprise.

also includes drive-by typo and test definition fixes

_Describe the problem or feature in addition to a link to the issues._

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] The code passes all CI tests without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [x] You have added an entry in any relevant CHANGELOGs (when appropriate).
- [ ] If you have made any changes to the `scripts/` or `docker/` directories, please ensure any image versions have been incremented accordingly!
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).